### PR TITLE
Add FakeFirestore.FieldValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Your application doesn't double-check firestore's response -- it trusts that it'
 
 ### Functions you can test
 
-#### Firestore
+#### [Firestore](https://googleapis.dev/nodejs/firestore/latest/Firestore.html)
 
 | Method                | Use                                                                                               | Method in Firestore                                                                              |
 | --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -191,7 +191,17 @@ Your application doesn't double-check firestore's response -- it trusts that it'
 | `mockOrderBy`         | Assert correct field is passed to orderBy                                                         | [orderBy](https://googleapis.dev/nodejs/firestore/latest/Query.html#orderBy)                     |
 | `mockLimit`           | Assert limit is set properly                                                                      | [limit](https://googleapis.dev/nodejs/firestore/latest/Query.html#limit)                         |
 
-#### Auth
+#### [Firestore.FieldValue](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html)
+
+| Method                          | Use                                                        | Method in Firestore                                                                                |
+| ------------------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `mockArrayRemoveFieldValue`     | Assert the correct elements are removed from an array      | [arrayRemove](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html#.arrayRemove)         |
+| `mockArrayUnionFieldValue`      | Assert the correct elements are added to an array          | [arrayUnion](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html#.arrayUnion)           |
+| `mockDeleteFieldValue`          | Assert the correct fields are removed from a document      | [delete](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html#.delete)                   |
+| `mockIncrementFieldValue`       | Assert a number field is incremented by the correct amount | [increment](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html#.increment)             |
+| `mockServerTimestampFieldValue` | Assert a server Firebase.Timestamp value will be stored    | [serverTimestamp](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html#.serverTimestamp) |
+
+#### [Auth](https://firebase.google.com/docs/reference/js/firebase.auth.Auth)
 
 | Method                               | Use                                                                        | Method in Firebase                                                                                                                     |
 | ------------------------------------ | -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |

--- a/__tests__/mock-fieldvalue.test.js
+++ b/__tests__/mock-fieldvalue.test.js
@@ -7,7 +7,7 @@ const {
   mockServerTimestampFieldValue,
 } = require('firestore-jest-mock/mocks/firestore');
 
-describe('Single records modified with field sentinels', () => {
+describe('Single values transformed by field sentinels', () => {
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
@@ -30,13 +30,13 @@ describe('Single records modified with field sentinels', () => {
     const increment = firestore.FieldValue.increment;
     const value = 5;
 
-    expect(increment().updateValue(value)).toBe(6);
-    expect(increment(1).updateValue(value)).toBe(6);
+    expect(increment().transform(value)).toBe(6);
+    expect(increment(1).transform(value)).toBe(6);
 
-    expect(increment(0).updateValue(value)).toBe(value);
+    expect(increment(0).transform(value)).toBe(value);
 
-    expect(increment(-1).updateValue(value)).toBe(4);
-    expect(increment(-8).updateValue(value)).toBe(-3);
+    expect(increment(-1).transform(value)).toBe(4);
+    expect(increment(-8).transform(value)).toBe(-3);
 
     expect(mockIncrementFieldValue).toHaveBeenCalled();
   });
@@ -44,10 +44,10 @@ describe('Single records modified with field sentinels', () => {
   test('it does not increment non-number values', () => {
     const increment = firestore.FieldValue.increment;
 
-    expect(increment().updateValue('5')).toBe(1);
-    expect(increment().updateValue()).toBe(1);
+    expect(increment().transform('5')).toBe(1);
+    expect(increment().transform()).toBe(1);
 
-    expect(increment(8).updateValue({})).toBe(8);
+    expect(increment(8).transform({})).toBe(8);
 
     expect(mockIncrementFieldValue).toHaveBeenCalled();
   });
@@ -56,26 +56,26 @@ describe('Single records modified with field sentinels', () => {
     const arrayUnion = firestore.FieldValue.arrayUnion;
     const value = [1, 2, 3];
 
-    expect(arrayUnion([4, 5, 6]).updateValue(value)).toStrictEqual([1, 2, 3, 4, 5, 6]);
-    expect(arrayUnion([3, 4, 5]).updateValue(value)).toStrictEqual([1, 2, 3, 4, 5]);
+    expect(arrayUnion([4, 5, 6]).transform(value)).toStrictEqual([1, 2, 3, 4, 5, 6]);
+    expect(arrayUnion([3, 4, 5]).transform(value)).toStrictEqual([1, 2, 3, 4, 5]);
 
-    expect(arrayUnion([4]).updateValue(value)).toStrictEqual([1, 2, 3, 4]);
-    expect(arrayUnion(4).updateValue(value)).toStrictEqual([1, 2, 3, 4]);
-    expect(arrayUnion([3]).updateValue(value)).toStrictEqual(value);
-    expect(arrayUnion(3).updateValue(value)).toStrictEqual(value);
-    expect(arrayUnion('3').updateValue(value)).toStrictEqual([1, 2, 3, '3']);
+    expect(arrayUnion([4]).transform(value)).toStrictEqual([1, 2, 3, 4]);
+    expect(arrayUnion(4).transform(value)).toStrictEqual([1, 2, 3, 4]);
+    expect(arrayUnion([3]).transform(value)).toStrictEqual(value);
+    expect(arrayUnion(3).transform(value)).toStrictEqual(value);
+    expect(arrayUnion('3').transform(value)).toStrictEqual([1, 2, 3, '3']);
 
-    expect(arrayUnion(value).updateValue(value)).toStrictEqual(value);
-    expect(arrayUnion([]).updateValue(value)).toStrictEqual(value);
-    expect(arrayUnion().updateValue(value)).toStrictEqual(value);
+    expect(arrayUnion(value).transform(value)).toStrictEqual(value);
+    expect(arrayUnion([]).transform(value)).toStrictEqual(value);
+    expect(arrayUnion().transform(value)).toStrictEqual(value);
 
     const num = 3;
-    expect(arrayUnion([3]).updateValue(num)).toStrictEqual([3]);
-    expect(arrayUnion([3]).updateValue(undefined)).toStrictEqual([3]);
+    expect(arrayUnion([3]).transform(num)).toStrictEqual([3]);
+    expect(arrayUnion([3]).transform(undefined)).toStrictEqual([3]);
 
     // A string should not be treated like a character array
     const str = '3';
-    expect(arrayUnion([3]).updateValue(str)).toStrictEqual([3]);
+    expect(arrayUnion([3]).transform(str)).toStrictEqual([3]);
 
     expect(mockArrayUnionFieldValue).toHaveBeenCalled();
   });
@@ -84,27 +84,27 @@ describe('Single records modified with field sentinels', () => {
     const arrayRemove = firestore.FieldValue.arrayRemove;
     const value = [1, 2, 3];
 
-    expect(arrayRemove([4, 5, 6]).updateValue(value)).toStrictEqual(value);
-    expect(arrayRemove([3, 4, 5]).updateValue(value)).toStrictEqual([1, 2]);
-    expect(arrayRemove('3').updateValue(value)).toStrictEqual(value);
+    expect(arrayRemove([4, 5, 6]).transform(value)).toStrictEqual(value);
+    expect(arrayRemove([3, 4, 5]).transform(value)).toStrictEqual([1, 2]);
+    expect(arrayRemove('3').transform(value)).toStrictEqual(value);
 
-    expect(arrayRemove(value).updateValue(value)).toStrictEqual([]);
-    expect(arrayRemove([]).updateValue(value)).toStrictEqual(value);
-    expect(arrayRemove().updateValue(value)).toStrictEqual(value);
+    expect(arrayRemove(value).transform(value)).toStrictEqual([]);
+    expect(arrayRemove([]).transform(value)).toStrictEqual(value);
+    expect(arrayRemove().transform(value)).toStrictEqual(value);
 
     const num = 3;
-    expect(arrayRemove([3]).updateValue(num)).toStrictEqual(num);
-    expect(arrayRemove([3]).updateValue(undefined)).toBeUndefined();
+    expect(arrayRemove([3]).transform(num)).toStrictEqual(num);
+    expect(arrayRemove([3]).transform(undefined)).toBeUndefined();
 
     // A string should not be treated like a character array
     const str = '3';
-    expect(arrayRemove([3]).updateValue(str)).toStrictEqual(str);
+    expect(arrayRemove([3]).transform(str)).toStrictEqual(str);
 
     expect(mockArrayRemoveFieldValue).toHaveBeenCalled();
   });
 
   test('it returns a Timestamp object', () => {
-    const timestamp = firestore.FieldValue.serverTimestamp().updateValue();
+    const timestamp = firestore.FieldValue.serverTimestamp().transform();
     expect(mockServerTimestampFieldValue).toHaveBeenCalled();
     expect(timestamp).toHaveProperty('seconds');
     expect(timestamp).toHaveProperty('nanoseconds');
@@ -116,9 +116,9 @@ describe('Single records modified with field sentinels', () => {
       some: 'thing',
     };
 
-    expect(deleteValue().updateValue(object.some)).toBeUndefined();
+    expect(deleteValue().transform(object.some)).toBeUndefined();
     expect(object.some).toBeDefined();
-    object.some = deleteValue().updateValue(object.some);
+    object.some = deleteValue().transform(object.some);
     expect(object.some).toBeUndefined();
 
     expect(mockDeleteFieldValue).toHaveBeenCalled();

--- a/__tests__/mock-fieldvalue.test.js
+++ b/__tests__/mock-fieldvalue.test.js
@@ -1,0 +1,126 @@
+const { FakeFirestore } = require('firestore-jest-mock');
+const {
+  mockArrayRemoveFieldValue,
+  mockArrayUnionFieldValue,
+  mockDeleteFieldValue,
+  mockIncrementFieldValue,
+  mockServerTimestampFieldValue,
+} = require('firestore-jest-mock/mocks/firestore');
+
+describe('Single records modified with field sentinels', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const firestore = FakeFirestore;
+
+  test('it can be distinguished from other field values', () => {
+    const incrementBy1 = firestore.FieldValue.increment();
+    const unionNothing = firestore.FieldValue.arrayUnion();
+
+    expect(incrementBy1.isEqual(incrementBy1)).toBe(true);
+    expect(unionNothing.isEqual(unionNothing)).toBe(true);
+    expect(incrementBy1.isEqual(unionNothing)).toBe(false);
+
+    expect(mockIncrementFieldValue).toHaveBeenCalled();
+  });
+
+  test('it increments number values', () => {
+    const increment = firestore.FieldValue.increment;
+    const value = 5;
+
+    expect(increment().updateValue(value)).toBe(6);
+    expect(increment(1).updateValue(value)).toBe(6);
+
+    expect(increment(0).updateValue(value)).toBe(value);
+
+    expect(increment(-1).updateValue(value)).toBe(4);
+    expect(increment(-8).updateValue(value)).toBe(-3);
+
+    expect(mockIncrementFieldValue).toHaveBeenCalled();
+  });
+
+  test('it does not increment non-number values', () => {
+    const increment = firestore.FieldValue.increment;
+
+    expect(increment().updateValue('5')).toBe(1);
+    expect(increment().updateValue()).toBe(1);
+
+    expect(increment(8).updateValue({})).toBe(8);
+
+    expect(mockIncrementFieldValue).toHaveBeenCalled();
+  });
+
+  test('it adds to arrays, but only elements not already present', () => {
+    const arrayUnion = firestore.FieldValue.arrayUnion;
+    const value = [1, 2, 3];
+
+    expect(arrayUnion([4, 5, 6]).updateValue(value)).toStrictEqual([1, 2, 3, 4, 5, 6]);
+    expect(arrayUnion([3, 4, 5]).updateValue(value)).toStrictEqual([1, 2, 3, 4, 5]);
+
+    expect(arrayUnion([4]).updateValue(value)).toStrictEqual([1, 2, 3, 4]);
+    expect(arrayUnion(4).updateValue(value)).toStrictEqual([1, 2, 3, 4]);
+    expect(arrayUnion([3]).updateValue(value)).toStrictEqual(value);
+    expect(arrayUnion(3).updateValue(value)).toStrictEqual(value);
+    expect(arrayUnion('3').updateValue(value)).toStrictEqual([1, 2, 3, '3']);
+
+    expect(arrayUnion(value).updateValue(value)).toStrictEqual(value);
+    expect(arrayUnion([]).updateValue(value)).toStrictEqual(value);
+    expect(arrayUnion().updateValue(value)).toStrictEqual(value);
+
+    const num = 3;
+    expect(arrayUnion([3]).updateValue(num)).toStrictEqual([3]);
+    expect(arrayUnion([3]).updateValue(undefined)).toStrictEqual([3]);
+
+    // A string should not be treated like a character array
+    const str = '3';
+    expect(arrayUnion([3]).updateValue(str)).toStrictEqual([3]);
+
+    expect(mockArrayUnionFieldValue).toHaveBeenCalled();
+  });
+
+  test('it removes values from arrays', () => {
+    const arrayRemove = firestore.FieldValue.arrayRemove;
+    const value = [1, 2, 3];
+
+    expect(arrayRemove([4, 5, 6]).updateValue(value)).toStrictEqual(value);
+    expect(arrayRemove([3, 4, 5]).updateValue(value)).toStrictEqual([1, 2]);
+    expect(arrayRemove('3').updateValue(value)).toStrictEqual(value);
+
+    expect(arrayRemove(value).updateValue(value)).toStrictEqual([]);
+    expect(arrayRemove([]).updateValue(value)).toStrictEqual(value);
+    expect(arrayRemove().updateValue(value)).toStrictEqual(value);
+
+    const num = 3;
+    expect(arrayRemove([3]).updateValue(num)).toStrictEqual(num);
+    expect(arrayRemove([3]).updateValue(undefined)).toBeUndefined();
+
+    // A string should not be treated like a character array
+    const str = '3';
+    expect(arrayRemove([3]).updateValue(str)).toStrictEqual(str);
+
+    expect(mockArrayRemoveFieldValue).toHaveBeenCalled();
+  });
+
+  test('it returns a Timestamp object', () => {
+    const timestamp = firestore.FieldValue.serverTimestamp().updateValue();
+    expect(mockServerTimestampFieldValue).toHaveBeenCalled();
+    expect(timestamp).toHaveProperty('seconds');
+    expect(timestamp).toHaveProperty('nanoseconds');
+  });
+
+  test('it deletes values', () => {
+    const deleteValue = firestore.FieldValue.delete;
+    const object = {
+      some: 'thing',
+    };
+
+    expect(deleteValue().updateValue(object.some)).toBeUndefined();
+    expect(object.some).toBeDefined();
+    object.some = deleteValue().updateValue(object.some);
+    expect(object.some).toBeUndefined();
+
+    expect(mockDeleteFieldValue).toHaveBeenCalled();
+  });
+});

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -14,8 +14,10 @@ const firebaseStub = overrides => {
       return new FakeAuth(overrides.currentUser);
     },
 
-    firestore() {
-      return new FakeFirestore(overrides.database);
+    firestore: class extends FakeFirestore {
+      constructor() {
+        super(overrides.database);
+      }
     },
   };
 };

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -14,10 +14,9 @@ const firebaseStub = overrides => {
       return new FakeAuth(overrides.currentUser);
     },
 
-    firestore: class extends FakeFirestore {
-      constructor() {
-        super(overrides.database);
-      }
+    firestore: function firestoreConstructor() {
+      firestoreConstructor.FieldValue = FakeFirestore.FieldValue;
+      return new FakeFirestore(overrides.database);
     },
   };
 };

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -16,6 +16,7 @@ const firebaseStub = overrides => {
 
     firestore: function firestoreConstructor() {
       firestoreConstructor.FieldValue = FakeFirestore.FieldValue;
+      firestoreConstructor.Timestamp = FakeFirestore.Timestamp;
       return new FakeFirestore(overrides.database);
     },
   };

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -12,6 +12,12 @@ const mockDelete = jest.fn();
 const mockOrderBy = jest.fn();
 const mockLimit = jest.fn();
 
+const mockArrayRemoveFieldValue = jest.fn();
+const mockArrayUnionFieldValue = jest.fn();
+const mockDeleteFieldValue = jest.fn();
+const mockIncrementFieldValue = jest.fn();
+const mockServerTimestampFieldValue = jest.fn();
+
 const mockBatchDelete = jest.fn();
 const mockBatchCommit = jest.fn();
 const mockBatchUpdate = jest.fn();
@@ -180,6 +186,83 @@ class FakeFirestore {
   }
 }
 
+FakeFirestore.FieldValue = class {
+  constructor(type, value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  isEqual(other) {
+    return (
+      other instanceof FakeFirestore.FieldValue &&
+      other.type === this.type &&
+      other.value === this.value
+    );
+  }
+
+  updateValue(value) {
+    switch (this.type) {
+      case 'arrayUnion':
+        if (Array.isArray(value)) {
+          return value.concat(this.value.filter(v => !value.includes(v)));
+        } else {
+          return this.value;
+        }
+      case 'arrayRemove':
+        if (Array.isArray(value)) {
+          return value.filter(v => !this.value.includes(v));
+        } else {
+          return value;
+        }
+      case 'increment': {
+        const amount = Number(this.value);
+        if (typeof value === 'number') {
+          return value + amount;
+        } else {
+          return amount;
+        }
+      }
+      case 'serverTimestamp': {
+        const now = Date.now();
+        return { seconds: now / 1000, nanoseconds: now % 1000 };
+      }
+      case 'delete':
+        return undefined;
+    }
+  }
+
+  static arrayUnion(elements = []) {
+    mockArrayUnionFieldValue(...arguments);
+    if (!Array.isArray(elements)) {
+      elements = [elements];
+    }
+    return new FakeFirestore.FieldValue('arrayUnion', elements);
+  }
+
+  static arrayRemove(elements) {
+    mockArrayRemoveFieldValue(...arguments);
+    if (!Array.isArray(elements)) {
+      elements = [elements];
+    }
+    return new FakeFirestore.FieldValue('arrayRemove', elements);
+  }
+
+  static increment(amount = 1) {
+    mockIncrementFieldValue(...arguments);
+    return new FakeFirestore.FieldValue('increment', amount);
+  }
+
+  static serverTimestamp() {
+    mockServerTimestampFieldValue(...arguments);
+    return new FakeFirestore.FieldValue('serverTimestamp');
+  }
+
+  static delete() {
+    mockDeleteFieldValue(...arguments);
+    return new FakeFirestore.FieldValue('delete');
+  }
+};
+
 module.exports = {
   FakeFirestore,
   mockAdd,
@@ -194,6 +277,11 @@ module.exports = {
   mockSet,
   mockUpdate,
   mockWhere,
+  mockArrayRemoveFieldValue,
+  mockArrayUnionFieldValue,
+  mockDeleteFieldValue,
+  mockIncrementFieldValue,
+  mockServerTimestampFieldValue,
   mockBatchDelete,
   mockBatchCommit,
   mockBatchUpdate,

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -200,7 +200,7 @@ FakeFirestore.FieldValue = class {
     );
   }
 
-  updateValue(value) {
+  transform(value) {
     switch (this.type) {
       case 'arrayUnion':
         if (Array.isArray(value)) {

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -270,7 +270,7 @@ FakeFirestore.Timestamp = class {
 
   static now() {
     const now = Date.now();
-    return new FakeFirestore.FieldValue.Timestamp(now / 1000, 0);
+    return new FakeFirestore.Timestamp(now / 1000, 0);
   }
 
   isEqual(other) {

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -223,8 +223,7 @@ FakeFirestore.FieldValue = class {
         }
       }
       case 'serverTimestamp': {
-        const now = Date.now();
-        return { seconds: now / 1000, nanoseconds: now % 1000 };
+        return FakeFirestore.Timestamp.now();
       }
       case 'delete':
         return undefined;
@@ -260,6 +259,26 @@ FakeFirestore.FieldValue = class {
   static delete() {
     mockDeleteFieldValue(...arguments);
     return new FakeFirestore.FieldValue('delete');
+  }
+};
+
+FakeFirestore.Timestamp = class {
+  constructor(seconds, nanoseconds) {
+    this.seconds = seconds;
+    this.nanoseconds = nanoseconds;
+  }
+
+  static now() {
+    const now = Date.now();
+    return new FakeFirestore.FieldValue.Timestamp(now / 1000, 0);
+  }
+
+  isEqual(other) {
+    return (
+      other instanceof FakeFirestore.FieldValue.Timestamp &&
+      other.seconds === this.seconds &&
+      other.nanoseconds === this.nanoseconds
+    );
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-jest-mock",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "Jest helper for mocking Google Cloud Firestore",
   "author": "",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-jest-mock",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Jest helper for mocking Google Cloud Firestore",
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
# Description
Added a `firestore.FieldValue` mock to `FakeFirestore`. An instance of this new `FakeFirestore.FieldValue` class is normally created by calling one of its static functions: `arrayUnion`, `arrayRemove`, `increment`, `serverTimestamp`, and `delete`. These each should correspond to Firebase Firestore's own [`FieldValue` API](https://firebase.google.com/docs/reference/js/firebase.firestore.FieldValue).

Each `FakeFirestore.FieldValue` instance represents a sentinel that contains information on how to transform arbitrary values. If we so choose, we may modify `set`, `update`, and `add` to actively transform mock data using these sentinels.

The new `FakeFirestore.FieldValue` class can return transformed versions of arbitrary values by passing the value to its `transform` function.

## Related issues
Fixes #23 

## How to test
Run `jest` or `jest --verbose`.