### PR TITLE
Fix jest error on missing dependencies

### DIFF
--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -21,8 +21,17 @@ const firebaseStub = overrides => {
 };
 
 const mockFirebase = (overrides = {}) => {
-  jest.mock('firebase', () => firebaseStub(overrides)) &&
-    jest.mock('firebase-admin', () => firebaseStub(overrides));
+  mockModuleIfFound('firebase', overrides);
+  mockModuleIfFound('firebase-admin', overrides);
+};
+
+function mockModuleIfFound(moduleName, overrides) {
+  try {
+    require.resolve(moduleName);
+    jest.mock(moduleName, () => firebaseStub(overrides));
+  } catch(e) {
+    // module ${moduleName} not found, skipping
+  }
 };
 
 module.exports = {

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -30,7 +30,8 @@ function mockModuleIfFound(moduleName, overrides) {
     require.resolve(moduleName);
     jest.doMock(moduleName, () => firebaseStub(overrides));
   } catch (e) {
-    // module ${moduleName} not found, skipping
+    // eslint-disable-next-line no-console
+    console.info('Module ${moduleName} not found, mocking skipped.');
   }
 }
 

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -28,11 +28,11 @@ const mockFirebase = (overrides = {}) => {
 function mockModuleIfFound(moduleName, overrides) {
   try {
     require.resolve(moduleName);
-    jest.mock(moduleName, () => firebaseStub(overrides));
-  } catch(e) {
+    jest.doMock(moduleName, () => firebaseStub(overrides));
+  } catch (e) {
     // module ${moduleName} not found, skipping
   }
-};
+}
 
 module.exports = {
   firebaseStub,


### PR DESCRIPTION
# Description

In our project, we use only `firebase-admin` package and there is no `firebase` module imported.

When I attempt to mock `firestore` in such scenario, it fails (`Cannot find module 'firebase' from 'node_modules/firestore-jest-mock/mocks/firebase.js'`). That's because jest can not find `firebase` module in this line: `jest.doMock('firebase', () => firebaseStub(overrides));`

This change applies mocking only if a respective module can be found as a dependency. `require.resolve()` was the best way I found to check if a package can be found, but it throws an exception if a module was not found - therefore the empty `catch`.

In addition, I changed the usage of the `mock` functions to `doMock` - when plain mocking was replaced with the function call the `&&` trick did not work anymore and `babel-plugin-jest-hoist` reported an error: `The module factory of jest.mock() is not allowed to reference any out-of-scope variables.`

## Related issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## How to test

Try mocking in a project which has a dependency to `firebase-admin` but not to `firebase` - before and after the change.
