### PR TITLE
Fix console.info - use template string

### DIFF
--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -31,7 +31,7 @@ function mockModuleIfFound(moduleName, overrides) {
     jest.doMock(moduleName, () => firebaseStub(overrides));
   } catch (e) {
     // eslint-disable-next-line no-console
-    console.info('Module ${moduleName} not found, mocking skipped.');
+    console.info(`Module ${moduleName} not found, mocking skipped.`);
   }
 }
 


### PR DESCRIPTION
# Description

Fixes `console.info` introduced by me in https://github.com/Upstatement/firestore-jest-mock/pull/28 - 
it should use template string.

## Related issues

Related to PR https://github.com/Upstatement/firestore-jest-mock/pull/28

## How to test
