### PR TITLE
Add offset as a mock function

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Your application doesn't double-check firestore's response -- it trusts that it'
 | `mockDelete`          | Assert delete is called on ref. Returns a promise                                                 | [delete](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#delete)           |
 | `mockOrderBy`         | Assert correct field is passed to orderBy                                                         | [orderBy](https://googleapis.dev/nodejs/firestore/latest/Query.html#orderBy)                     |
 | `mockLimit`           | Assert limit is set properly                                                                      | [limit](https://googleapis.dev/nodejs/firestore/latest/Query.html#limit)                         |
+| `mockOffset`          | Assert offset is set properly                                                                     | [offset](https://googleapis.dev/nodejs/firestore/latest/Query.html#offset)                       |
 
 #### [Firestore.FieldValue](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html)
 

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -1,8 +1,4 @@
-const {
-  mockCollection,
-  mockGet,
-  mockWhere,
-} = require('../mocks/firestore');
+const { mockCollection, mockGet, mockWhere, mockOffset } = require('../mocks/firestore');
 
 const { mockFirebase } = require('firestore-jest-mock');
 
@@ -10,25 +6,61 @@ describe('test', () => {
   test('It can query firestore', async () => {
     mockFirebase({
       database: {
-        animals: [{ name: 'monkey', type: 'mammal' }, { name: 'elephant', type: 'mammal' }]
+        animals: [
+          { name: 'monkey', type: 'mammal' },
+          { name: 'elephant', type: 'mammal' },
+        ],
       },
-      currentUser: { uid: 'homer-user' }
+      currentUser: { uid: 'homer-user' },
     });
     const firebase = require('firebase');
     firebase.initializeApp({
       apiKey: '### FIREBASE API KEY ###',
       authDomain: '### FIREBASE AUTH DOMAIN ###',
-      projectId: '### CLOUD FIRESTORE PROJECT ID ###'
+      projectId: '### CLOUD FIRESTORE PROJECT ID ###',
     });
 
     const db = firebase.firestore();
 
-    const animals = await db.collection('animals')
+    const animals = await db
+      .collection('animals')
       .where('type', '==', 'mammal')
       .get();
 
+    expect(animals).toHaveProperty('docs', expect.any(Array));
     expect(mockWhere).toHaveBeenCalledWith('type', '==', 'mammal');
     expect(mockCollection).toHaveBeenCalledWith('animals');
     expect(mockGet).toHaveBeenCalled();
+  });
+
+  test('It can offset query', async () => {
+    mockFirebase({
+      database: {
+        animals: [
+          { name: 'monkey', type: 'mammal' },
+          { name: 'elephant', type: 'mammal' },
+          { name: 'lion', type: 'mammal' },
+        ],
+      },
+    });
+    const firebase = require('firebase');
+    firebase.initializeApp({
+      apiKey: '### FIREBASE API KEY ###',
+      authDomain: '### FIREBASE AUTH DOMAIN ###',
+      projectId: '### CLOUD FIRESTORE PROJECT ID ###',
+    });
+
+    const db = firebase.firestore();
+    const firstTwoMammals = await db
+      .collection('animals')
+      .where('type', '==', 'mammal')
+      .offset(2)
+      .get();
+
+    expect(firstTwoMammals).toHaveProperty('docs', expect.any(Array));
+    expect(mockWhere).toHaveBeenCalledWith('type', '==', 'mammal');
+    expect(mockCollection).toHaveBeenCalledWith('animals');
+    expect(mockGet).toHaveBeenCalled();
+    expect(mockOffset).toHaveBeenCalledWith(2);
   });
 });

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -299,6 +299,7 @@ module.exports = {
   mockGet,
   mockGetAll,
   mockOrderBy,
+  mockLimit,
   mockOffset,
   mockSet,
   mockUpdate,

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -11,6 +11,7 @@ const mockSet = jest.fn();
 const mockDelete = jest.fn();
 const mockOrderBy = jest.fn();
 const mockLimit = jest.fn();
+const mockOffset = jest.fn();
 
 const mockArrayRemoveFieldValue = jest.fn();
 const mockArrayUnionFieldValue = jest.fn();
@@ -184,6 +185,11 @@ class FakeFirestore {
     mockLimit(...arguments);
     return this;
   }
+
+  offset() {
+    mockOffset(...arguments);
+    return this;
+  }
 }
 
 FakeFirestore.FieldValue = class {
@@ -293,6 +299,7 @@ module.exports = {
   mockGet,
   mockGetAll,
   mockOrderBy,
+  mockOffset,
   mockSet,
   mockUpdate,
   mockWhere,


### PR DESCRIPTION
# Description

- Adds mockCollectionGroup as a mocked function in firestore.js
- Fix mockLimit export that was missing
- Adds tests in query.test.js

## Related issues


## How to test

Run test for query.test.js 
