### PR TITLE
adding get function to fake document snapshot

### DIFF
--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -9,7 +9,12 @@ describe('Single records versus queries', () => {
 
   const db = new FakeFirestore({
     characters: [
-      { id: 'homer', name: 'Homer', occupation: 'technician' },
+      {
+        id: 'homer',
+        name: 'Homer',
+        occupation: 'technician',
+        address: { street: '742 Evergreen Terrace' },
+      },
       { id: 'krusty', name: 'Krusty', occupation: 'clown' },
     ],
   });
@@ -34,30 +39,35 @@ describe('Single records versus queries', () => {
     expect(record.exists).toBe(false);
   });
 
-  test('it can fetch a single record with a promise', () => db
-    .collection('characters')
-    .doc('homer')
-    .get()
-    .then(record => {
-      expect(record.exists).toBe(true);
-      expect(record.id).toBe('homer');
-      const data = record.data();
-      expect(mockCollection).toHaveBeenCalledWith('characters');
-      expect(data).toHaveProperty('name', 'Homer');
-      expect(data).toHaveProperty('occupation', 'technician');
-    }));
+  test('it can fetch a single record with a promise', () =>
+    db
+      .collection('characters')
+      .doc('homer')
+      .get()
+      .then(record => {
+        expect(record.exists).toBe(true);
+        expect(record.id).toBe('homer');
+        const data = record.data();
+        expect(mockCollection).toHaveBeenCalledWith('characters');
+        expect(data).toHaveProperty('name', 'Homer');
+        expect(data).toHaveProperty('occupation', 'technician');
 
-  test('it can fetch a single record with a promise without a specified collection', () => db
-    .doc('characters/homer')
-    .get()
-    .then(record => {
-      expect(record.exists).toBe(true);
-      expect(record.id).toBe('homer');
-      const data = record.data();
-      expect(mockCollection).not.toHaveBeenCalled();
-      expect(data).toHaveProperty('name', 'Homer');
-      expect(data).toHaveProperty('occupation', 'technician');
-    }));
+        expect(record.get('name')).toEqual('Homer');
+        expect(record.get('address.street')).toEqual('742 Evergreen Terrace');
+      }));
+
+  test('it can fetch a single record with a promise without a specified collection', () =>
+    db
+      .doc('characters/homer')
+      .get()
+      .then(record => {
+        expect(record.exists).toBe(true);
+        expect(record.id).toBe('homer');
+        const data = record.data();
+        expect(mockCollection).not.toHaveBeenCalled();
+        expect(data).toHaveProperty('name', 'Homer');
+        expect(data).toHaveProperty('occupation', 'technician');
+      }));
 
   test('it can fetch multiple records and returns documents', async () => {
     const records = await db
@@ -79,16 +89,17 @@ describe('Single records versus queries', () => {
     expect(records.empty).toBe(true);
   });
 
-  test('it can fetch multiple records as a promise', () => db
-    .collection('characters')
-    .where('name', '==', 'Homer')
-    .get()
-    .then(records => {
-      expect(records.empty).toBe(false);
-      expect(records).toHaveProperty('docs', expect.any(Array));
-      expect(records.docs[0]).toHaveProperty('id', 'homer');
-      expect(records.docs[0].data()).toHaveProperty('name', 'Homer');
-    }));
+  test('it can fetch multiple records as a promise', () =>
+    db
+      .collection('characters')
+      .where('name', '==', 'Homer')
+      .get()
+      .then(records => {
+        expect(records.empty).toBe(false);
+        expect(records).toHaveProperty('docs', expect.any(Array));
+        expect(records.docs[0]).toHaveProperty('id', 'homer');
+        expect(records.docs[0].data()).toHaveProperty('name', 'Homer');
+      }));
 
   test('it can return all records', async () => {
     const firstRecord = db.collection('characters').doc('homer');

--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -77,6 +77,7 @@ describe('Queries', () => {
 
           expect(record.get('name')).toEqual('Homer');
           expect(record.get('address.street')).toEqual('742 Evergreen Terrace');
+          expect(record.get('address.street.doesntExist')).toBeNull();
         }));
 
     test('it can fetch a single record with a promise without a specified collection', () =>

--- a/mocks/helpers/buildDocFromHash.js
+++ b/mocks/helpers/buildDocFromHash.js
@@ -10,5 +10,15 @@ module.exports = function buildDocFromHash(hash = {}) {
       delete copy._ref;
       return copy;
     },
+    get(fieldPath) {
+      // The field path can be compound: from the firestore docs
+      //  fieldPath The path (e.g. 'foo' or 'foo.bar') to a specific field.
+      const parts = fieldPath.split('.');
+      let data = this.data();
+      parts.forEach(part => {
+        data = data[part];
+      });
+      return data;
+    },
   };
 };

--- a/mocks/helpers/buildDocFromHash.js
+++ b/mocks/helpers/buildDocFromHash.js
@@ -23,11 +23,19 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123') {
       // The field path can be compound: from the firestore docs
       //  fieldPath The path (e.g. 'foo' or 'foo.bar') to a specific field.
       const parts = fieldPath.split('.');
-      let data = this.data();
-      parts.forEach(part => {
-        data = data[part];
-      });
-      return data;
+      const data = this.data();
+      return parts.reduce((acc, part, index) => {
+        const value = acc[part];
+        // if no key is found
+        if (value === undefined) {
+          // return null if we are on the last item in parts
+          // otherwise, return an empty object, so we can continue to iterate
+          return parts.length - 1 === index ? null : {};
+        }
+
+        // if there is a value, return it
+        return value;
+      }, data);
     },
   };
 };


### PR DESCRIPTION
(cherry picked from commit 8e5bb8b504962e5495675c50280e93aa90a43c40)

# Description

adds `get` function to the fake DocumentSnapshot, compatible with Firestore

## Related issues

The following code threw an exception:
```
  const allDocs = await collection.get();
  allDocs.docs.map(async (d) => {
    const path = d.get('ref'); // get is not implemented
```

## How to test

Unit test included

Side note: apologies for the white-space noise, somehow the linting must have gotten confused.  Hopefully not conflicts because of this...