### PR TITLE
Settings and path split

### DIFF
--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -65,6 +65,10 @@ class FakeFirestore {
     };
   }
 
+  settings(settings) {
+    return;
+  }
+
   collection(collectionName) {
     mockCollection(...arguments);
     return new FakeFirestore.CollectionReference(collectionName, null, this);

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -2,6 +2,7 @@ const mockCollectionGroup = jest.fn();
 const mockBatch = jest.fn();
 const mockRunTransaction = jest.fn();
 
+const mockSettings = jest.fn();
 const mockCollection = jest.fn();
 const mockDoc = jest.fn();
 const mockUpdate = jest.fn();
@@ -65,7 +66,8 @@ class FakeFirestore {
     };
   }
 
-  settings(settings) {
+  settings() {
+    mockSettings(...arguments);
     return;
   }
 

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -82,7 +82,8 @@ class FakeFirestore {
   doc(path) {
     mockDoc(path);
 
-    const pathArray = path.split('/');
+    // Ignore leading slash
+    const pathArray = path.replace(/^\/+/, '').split('/')
     // Must be document-level, so even-numbered elements
     if (pathArray.length % 2) {
       throw new Error('The path array must be document-level');
@@ -138,7 +139,8 @@ FakeFirestore.DocumentReference = class {
 
   get() {
     query.mocks.mockGet(...arguments);
-    const pathArray = this.path.split('/');
+    // Ignore leading slash
+    const pathArray = this.path.replace(/^\/+/, '').split('/');
 
     pathArray.shift(); // drop 'database'; it's always first
     let requestedRecords = this.firestore.database[pathArray.shift()];
@@ -252,7 +254,8 @@ FakeFirestore.CollectionReference = class extends FakeFirestore.Query {
    * @returns {Object[]} An array of mocked document records.
    */
   records() {
-    const pathArray = this.path.split('/');
+    // Ignore leading slash
+    const pathArray = this.path.replace(/^\/+/, '').split('/')
 
     pathArray.shift(); // drop 'database'; it's always first
     let requestedRecords = this.firestore.database[pathArray.shift()];


### PR DESCRIPTION
# Description

1. Allow calling `settings()`:
```ts
export const db = admin.firestore();
db.settings({ ignoreUndefinedProperties: true });
```
2. Support collection/doc path names with leading slash (e.g., '/users/aUser' vs 'users/aUser') which are supported by firestore
