### PR TITLE
add onSnapshot method for queries and doc requests

### DIFF
--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -155,9 +155,13 @@ FakeFirestore.DocumentReference = class {
         [options, callback, errorCallback] = arguments;
       }
 
-      this.get().then(result => {
-        callback(result);
-      });
+      this.get()
+        .then(result => {
+          callback(result);
+        })
+        .catch(e => {
+          throw e;
+        });
     } catch (e) {
       errorCallback(e);
     }

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -15,6 +15,8 @@ const mockBatchCommit = jest.fn();
 const mockBatchUpdate = jest.fn();
 const mockBatchSet = jest.fn();
 
+const mockOnSnapShot = jest.fn();
+
 const timestamp = require('./timestamp');
 const fieldValue = require('./fieldValue');
 const query = require('./query');
@@ -137,6 +139,31 @@ FakeFirestore.DocumentReference = class {
   delete() {
     mockDelete(...arguments);
     return Promise.resolve();
+  }
+
+  onSnapshot() {
+    mockOnSnapShot(...arguments);
+    let callback;
+    let errorCallback;
+    // eslint-disable-next-line
+    let options;
+
+    try {
+      if (typeof arguments[0] === 'function') {
+        [callback, errorCallback] = arguments;
+      } else {
+        [options, callback, errorCallback] = arguments;
+      }
+
+      this.get().then(result => {
+        callback(result);
+      });
+    } catch (e) {
+      errorCallback(e);
+    }
+
+    // Returns an unsubscribe function
+    return () => {};
   }
 
   get() {
@@ -325,6 +352,7 @@ module.exports = {
   mockBatchCommit,
   mockBatchUpdate,
   mockBatchSet,
+  mockOnSnapShot,
   ...query.mocks,
   ...transaction.mocks,
   ...fieldValue.mocks,

--- a/mocks/helpers/buildDocFromHash.js
+++ b/mocks/helpers/buildDocFromHash.js
@@ -4,6 +4,9 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123') {
     exists,
     id: (hash && hash.id) || id,
     ref: hash && hash._ref,
+    metadata: {
+      hasPendingWrites: 'Server',
+    },
     data() {
       if (!exists) {
         // From Firestore docs: "Returns 'undefined' if the document doesn't exist."

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -20,7 +20,7 @@ module.exports = function buildQuerySnapShot(requestedRecords) {
       return {
         forEach(callback) {
           // eslint-disable-next-line no-console
-          console.info('Firestore jest mock does not current support tracking changes');
+          console.info('Firestore jest mock does not currently support tracking changes');
           callback();
         },
       };

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -16,5 +16,14 @@ module.exports = function buildQuerySnapShot(requestedRecords) {
     forEach(callback) {
       docs.forEach(callback);
     },
+    docChanges() {
+      return {
+        forEach(callback) {
+          // eslint-disable-next-line no-console
+          console.info('Firestore jest mock does not current support tracking changes');
+          callback();
+        },
+      };
+    },
   };
 };

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -7,6 +7,7 @@ const mockOrderBy = jest.fn();
 const mockOffset = jest.fn();
 const mockStartAfter = jest.fn();
 const mockStartAt = jest.fn();
+const mockQueryOnSnapshot = jest.fn();
 
 class Query {
   constructor(collectionName, firestore) {
@@ -67,6 +68,21 @@ class Query {
   startAt() {
     return mockStartAt(...arguments) || this;
   }
+
+  onSnapshot() {
+    mockQueryOnSnapshot(...arguments);
+    const [callback, errorCallback] = arguments;
+    try {
+      this.get().then(result => {
+        callback(result);
+      });
+    } catch (e) {
+      errorCallback(e);
+    }
+
+    // Returns an unsubscribe function
+    return () => {};
+  }
 }
 
 module.exports = {
@@ -79,5 +95,6 @@ module.exports = {
     mockOffset,
     mockStartAfter,
     mockStartAt,
+    mockQueryOnSnapshot,
   },
 };


### PR DESCRIPTION
# Description

Adds mock functionality for listening to snapshot changes, as documented here:
https://firebase.google.com/docs/firestore/query-data/listen

This is a harder one to *truly* mock as it adds an observer to an outside service, which we can't really mock with a simple POJO.  Instead, this is meant to stupidly imitate a user's implementation so their tests don't get hung up on this unknown method.  A future update might add an observer class, so you can manually trigger these callbacks, but that gets into the territory of "too much logic for a stub."

## Related issues

Fixes https://github.com/Upstatement/firestore-jest-mock/issues/63

Conversation in there as to some of the complications and the underlying API's

## How to test

Taken examples from the documentation: https://firebase.google.com/docs/firestore/query-data/listen And making sure you can execute that code in our tests
