### PR TITLE
Implement doc().set

### DIFF
--- a/__tests__/mock-firestore.test.js
+++ b/__tests__/mock-firestore.test.js
@@ -60,6 +60,25 @@ describe('Queries', () => {
       expect(record.exists).toBe(false);
     });
 
+    test('it can set simple record data', async () => {
+      await db
+        .collection('animals')
+        .doc('fantasy')
+        .collection('dragons')
+        .doc('whisperingDeath')
+        .set({
+          age: 15,
+          food: 'omnivore',
+          special: 'tunneling',
+        });
+      expect(mockCollection).toHaveBeenCalledWith('dragons');
+      expect(mockDoc).toHaveBeenCalledWith('whisperingDeath');
+
+      const doc = await db.doc('animals/fantasy/dragons/whisperingDeath').get();
+      expect(doc.exists).toBe(true);
+      expect(doc.id).toBe('whisperingDeath');
+    });
+
     test('it can fetch a single record with a promise', () =>
       db
         .collection('characters')


### PR DESCRIPTION
# Description

Allows mutability of the mock by calling 'set' on a document.

## How to test

Unit test `'it can set simple record data'` tests iterating the db and setting document data.

This is not complete: update/merge functionality is absent (but would be trivial to add)
