### PR TITLE
feat: support auth signOut

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 | `mockSignInWithEmailAndPassword`     | Assert correct email and password were passed. Returns a promise           | [signInWithEmailAndPassword](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signinwithemailandpassword)         |
 | `mockSendPasswordResetEmail`         | Assert correct email was passed.                                           | [sendPasswordResetEmail](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#send-password-reset-email)              |
 | `mockVerifyIdToken`                  | Assert correct token is passed. Returns a promise                          | [verifyIdToken](https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth.html#verifyidtoken)                              |
-| `mockSignOut`                        | Assert sign out is called. Returns a promise                               | [signOut](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signout)
+| `mockSignOut`                        | Assert sign out is called. Returns a promise                               | [signOut](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signout)                                               |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 | `mockSignInWithEmailAndPassword`     | Assert correct email and password were passed. Returns a promise           | [signInWithEmailAndPassword](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signinwithemailandpassword)         |
 | `mockSendPasswordResetEmail`         | Assert correct email was passed.                                           | [sendPasswordResetEmail](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#send-password-reset-email)              |
 | `mockVerifyIdToken`                  | Assert correct token is passed. Returns a promise                          | [verifyIdToken](https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth.html#verifyidtoken)                              |
+| `mockSignOut`                        | Assert sign out is called. Returns a promise                               | [signOut](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signout)
 
 ## Contributing
 

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -3,6 +3,7 @@ const { mockInitializeApp } = require('../mocks/firebase');
 const {
   mockCreateUserWithEmailAndPassword,
   mockSignInWithEmailAndPassword,
+  mockSignOut,
   mockSendPasswordResetEmail,
   mockDeleteUser,
   mockVerifyIdToken,
@@ -60,6 +61,12 @@ describe('we can start a firebase application', () => {
         expect.assertions(1);
         await this.firebase.auth().signInWithEmailAndPassword('sam', 'hill');
         expect(mockSignInWithEmailAndPassword).toHaveBeenCalledWith('sam', 'hill');
+      });
+
+      test('sign out', async () => {
+        expect.assertions(1);
+        await this.firebase.auth().signOut();
+        expect(mockSignOut).toHaveBeenCalled();
       });
 
       test('send password reset email', async () => {

--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -6,6 +6,7 @@ const mockSendPasswordResetEmail = jest.fn();
 const mockVerifyIdToken = jest.fn();
 const mockGetUser = jest.fn();
 const mockSetCustomUserClaims = jest.fn();
+const mockSignOut = jest.fn();
 
 class FakeAuth {
   constructor(currentUser = {}) {
@@ -26,6 +27,11 @@ class FakeAuth {
   signInWithEmailAndPassword() {
     mockSignInWithEmailAndPassword(...arguments);
     return Promise.resolve({ user: this.currentUserRecord });
+  }
+
+  signOut() {
+    mockSignOut();
+    return Promise.resolve('👍');
   }
 
   sendPasswordResetEmail() {
@@ -58,6 +64,7 @@ module.exports = {
   mockSendPasswordResetEmail,
   mockSendVerificationEmail,
   mockSignInWithEmailAndPassword,
+  mockSignOut,
   mockVerifyIdToken,
   mockGetUser,
   mockSetCustomUserClaims,


### PR DESCRIPTION
# Description

Adds support for auth `signOut`

## How to test

```js
​import​ ​{​ ​mockSignOut​ ​}​ ​from​ ​'firestore-jest-mock/mocks/auth'​;

it('signs out',  async () => {
    const firebase = require('firebase');
    const auth = firebase.auth();

    await auth.signOut();

    expect(mockSignOut).toHaveBeenCalled():
});
```