### PR TITLE
feat: support auth and firestore useEmulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,19 +259,20 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 
 #### [Firestore](https://googleapis.dev/nodejs/firestore/latest/Firestore.html)
 
-| Method                | Use                                                                                               | Method in Firestore                                                                              |
-| --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `mockCollection`      | Assert the correct collection is being queried                                                    | [collection](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#collection)           |
-| `mockCollectionGroup` | Assert the correct collectionGroup is being queried                                               | [collectionGroup](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#collectionGroup) |
-| `mockDoc`             | Assert the correct record is being fetched by id. Tells the mock you are fetching a single record | [doc](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#doc)                         |
-| `mockBatch`           | Assert batch was called                                                                           | [batch](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#batch)                     |
-| `mockBatchDelete`     | Assert correct refs are passed                                                                    | [batch delete](https://googleapis.dev/nodejs/firestore/latest/WriteBatch.html#delete)            |
-| `mockBatchCommit`     | Assert commit is called. Returns a promise                                                        | [batch commit](https://googleapis.dev/nodejs/firestore/latest/WriteBatch.html#commit)            |
-| `mockGetAll`          | Assert correct refs are passed. Returns a promise resolving to array of docs.                     | [getAll](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#getAll)                   |
-| `mockUpdate`          | Assert correct params are passed to update. Returns a promise                                     | [update](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#update)           |
-| `mockAdd`             | Assert correct params are passed to add. Returns a promise resolving to the doc with new id       | [add](https://googleapis.dev/nodejs/firestore/latest/CollectionReference.html#add)               |
-| `mockSet`             | Assert correct params are passed to set. Returns a promise                                        | [set](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#set)                 |
-| `mockDelete`          | Assert delete is called on ref. Returns a promise                                                 | [delete](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#delete)           |
+| Method                | Use                                                                                               | Method in Firestore                                                                                   |
+| --------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `mockCollection`      | Assert the correct collection is being queried                                                    | [collection](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#collection)                |
+| `mockCollectionGroup` | Assert the correct collectionGroup is being queried                                               | [collectionGroup](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#collectionGroup)      |
+| `mockDoc`             | Assert the correct record is being fetched by id. Tells the mock you are fetching a single record | [doc](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#doc)                              |
+| `mockBatch`           | Assert batch was called                                                                           | [batch](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#batch)                          |
+| `mockBatchDelete`     | Assert correct refs are passed                                                                    | [batch delete](https://googleapis.dev/nodejs/firestore/latest/WriteBatch.html#delete)                 |
+| `mockBatchCommit`     | Assert commit is called. Returns a promise                                                        | [batch commit](https://googleapis.dev/nodejs/firestore/latest/WriteBatch.html#commit)                 |
+| `mockGetAll`          | Assert correct refs are passed. Returns a promise resolving to array of docs.                     | [getAll](https://googleapis.dev/nodejs/firestore/latest/Firestore.html#getAll)                        |
+| `mockUpdate`          | Assert correct params are passed to update. Returns a promise                                     | [update](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#update)                |
+| `mockAdd`             | Assert correct params are passed to add. Returns a promise resolving to the doc with new id       | [add](https://googleapis.dev/nodejs/firestore/latest/CollectionReference.html#add)                    |
+| `mockSet`             | Assert correct params are passed to set. Returns a promise                                        | [set](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#set)                      |
+| `mockDelete`          | Assert delete is called on ref. Returns a promise                                                 | [delete](https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#delete)                |
+| `mockUseEmulator`     | Assert correct host and port are passed                                                           | [useEmulator](https://firebase.google.com/docs/reference/js/firebase.firestore.Firestore#useemulator) |
 
 #### [Firestore.Query](https://googleapis.dev/nodejs/firestore/latest/Query.html)
 
@@ -327,6 +328,7 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 | `mockSignInWithEmailAndPassword`     | Assert correct email and password were passed. Returns a promise           | [signInWithEmailAndPassword](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#signinwithemailandpassword)         |
 | `mockSendPasswordResetEmail`         | Assert correct email was passed.                                           | [sendPasswordResetEmail](https://firebase.google.com/docs/reference/js/firebase.auth.Auth.html#send-password-reset-email)              |
 | `mockVerifyIdToken`                  | Assert correct token is passed. Returns a promise                          | [verifyIdToken](https://firebase.google.com/docs/reference/admin/node/admin.auth.Auth.html#verifyidtoken)                              |
+| `mockUseEmulator`                    | Assert correct emulator url is passed                                      | [useEmulator](https://firebase.google.com/docs/reference/js/firebase.auth.Auth#useemulator)                                            |
 
 ## Contributing
 

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -8,6 +8,7 @@ const {
   mockVerifyIdToken,
   mockGetUser,
   mockSetCustomUserClaims,
+  mockUseEmulator,
 } = require('../mocks/auth');
 
 describe('we can start a firebase application', () => {
@@ -46,6 +47,11 @@ describe('we can start a firebase application', () => {
   test('We can start an application', async () => {
     this.firebase.auth();
     expect(mockInitializeApp).toHaveBeenCalled();
+  });
+
+  test('We can use emulator', () => {
+    this.firebase.auth().useEmulator('http://localhost:9099');
+    expect(mockUseEmulator).toHaveBeenCalledWith('http://localhost:9099');
   });
 
   describe('Client Auth Operations', () => {

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -17,6 +17,7 @@ const {
   mockBatchSet,
   mockSettings,
   mockOnSnapShot,
+  mockUseEmulator,
 } = require('../mocks/firestore');
 
 describe('we can start a firebase application', () => {
@@ -55,6 +56,12 @@ describe('we can start a firebase application', () => {
     db.settings({ ignoreUndefinedProperties: true });
     expect(mockInitializeApp).toHaveBeenCalled();
     expect(mockSettings).toHaveBeenCalledWith({ ignoreUndefinedProperties: true });
+  });
+
+  test('we can use emulator', async () => {
+    const db = this.firebase.firestore();
+    db.useEmulator('localhost', 9000);
+    expect(mockUseEmulator).toHaveBeenCalledWith('localhost', 9000);
   });
 
   describe('Examples from documentation', () => {

--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -6,6 +6,7 @@ const mockSendPasswordResetEmail = jest.fn();
 const mockVerifyIdToken = jest.fn();
 const mockGetUser = jest.fn();
 const mockSetCustomUserClaims = jest.fn();
+const mockUseEmulator = jest.fn();
 
 class FakeAuth {
   constructor(currentUser = {}) {
@@ -45,6 +46,10 @@ class FakeAuth {
     return Promise.resolve(mockSetCustomUserClaims(...arguments) || {});
   }
 
+  useEmulator() {
+    mockUseEmulator(...arguments);
+  }
+
   get currentUser() {
     const { uid, ...data } = this.currentUser;
     return { uid, data };
@@ -61,4 +66,5 @@ module.exports = {
   mockVerifyIdToken,
   mockGetUser,
   mockSetCustomUserClaims,
+  mockUseEmulator,
 };

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -3,6 +3,7 @@ const mockBatch = jest.fn();
 const mockRunTransaction = jest.fn();
 
 const mockSettings = jest.fn();
+const mockUseEmulator = jest.fn();
 const mockCollection = jest.fn();
 const mockDoc = jest.fn();
 const mockUpdate = jest.fn();
@@ -71,6 +72,10 @@ class FakeFirestore {
   settings() {
     mockSettings(...arguments);
     return;
+  }
+
+  useEmulator() {
+    mockUseEmulator(...arguments);
   }
 
   collection(collectionName) {
@@ -352,6 +357,7 @@ module.exports = {
   mockUpdate,
   mockSet,
   mockSettings,
+  mockUseEmulator,
   mockBatchDelete,
   mockBatchCommit,
   mockBatchUpdate,


### PR DESCRIPTION
# Description

Add support for auth and firestore's `useEmulator` with `mockUseEmulator` exported from both

## How to test

```js
​import​ ​{​ ​mockUseEmulator​ ​}​ ​from​ ​'firestore-jest-mock/mocks/auth'​;

it('uses auth emulator',  () => {
    const firebase = require('firebase');
    const auth = firebase.auth();

    auth.useEmulator('http://localhost:9099');

    expect(mockUseEmulator).toHaveBeenCalledWith('http://localhost:9099'):
});
```

```js
​import​ ​{​ ​mockUseEmulator​ ​}​ ​from​ ​'firestore-jest-mock/mocks/firestore'​;

it('uses firestore emulator',  () => {
    const firebase = require('firebase');
    const db = firebase.firestore();

    db.useEmulator('localhost', 9000);

    expect(mockUseEmulator).toHaveBeenCalledWith('localhost', 9000):
});
```
