### PR TITLE
Feat/support withConverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 | `mockOffset`     | Assert offset is set properly                                                             | [offset](https://googleapis.dev/nodejs/firestore/latest/Query.html#offset)         |
 | `mockStartAfter` | Assert startAfter is called                                                               | [startAfter](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAfter) |
 | `mockStartAt`    | Assert startAt is called                                                                  | [startAt](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAt)       |
+| `mockWithConverter` | Assert withConverter is called                                                      | [withConverter](https://firebase.google.com/docs/reference/js/firebase.firestore.Query#withconverter) |
 
 #### [Firestore.FieldValue](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html)
 

--- a/README.md
+++ b/README.md
@@ -275,16 +275,16 @@ Your application doesn't double-check Firestore's response -- it trusts that it'
 
 #### [Firestore.Query](https://googleapis.dev/nodejs/firestore/latest/Query.html)
 
-| Method           | Use                                                                                       | Method in Firestore                                                                |
-| ---------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `mockGet`        | Assert get is called. Returns a promise resolving either to a single doc or querySnapshot | [get](https://googleapis.dev/nodejs/firestore/latest/Query.html#get)               |
-| `mockWhere`      | Assert the correct query is written. Tells the mock you are fetching multiple records     | [where](https://googleapis.dev/nodejs/firestore/latest/Query.html#where)           |
-| `mockLimit`      | Assert limit is set properly                                                              | [limit](https://googleapis.dev/nodejs/firestore/latest/Query.html#limit)           |
-| `mockOrderBy`    | Assert correct field is passed to orderBy                                                 | [orderBy](https://googleapis.dev/nodejs/firestore/latest/Query.html#orderBy)       |
-| `mockOffset`     | Assert offset is set properly                                                             | [offset](https://googleapis.dev/nodejs/firestore/latest/Query.html#offset)         |
-| `mockStartAfter` | Assert startAfter is called                                                               | [startAfter](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAfter) |
-| `mockStartAt`    | Assert startAt is called                                                                  | [startAt](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAt)       |
-| `mockWithConverter` | Assert withConverter is called                                                      | [withConverter](https://firebase.google.com/docs/reference/js/firebase.firestore.Query#withconverter) |
+| Method              | Use                                                                                       | Method in Firestore                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `mockGet`           | Assert get is called. Returns a promise resolving either to a single doc or querySnapshot | [get](https://googleapis.dev/nodejs/firestore/latest/Query.html#get)                                  |
+| `mockWhere`         | Assert the correct query is written. Tells the mock you are fetching multiple records     | [where](https://googleapis.dev/nodejs/firestore/latest/Query.html#where)                              |
+| `mockLimit`         | Assert limit is set properly                                                              | [limit](https://googleapis.dev/nodejs/firestore/latest/Query.html#limit)                              |
+| `mockOrderBy`       | Assert correct field is passed to orderBy                                                 | [orderBy](https://googleapis.dev/nodejs/firestore/latest/Query.html#orderBy)                          |
+| `mockOffset`        | Assert offset is set properly                                                             | [offset](https://googleapis.dev/nodejs/firestore/latest/Query.html#offset)                            |
+| `mockStartAfter`    | Assert startAfter is called                                                               | [startAfter](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAfter)                    |
+| `mockStartAt`       | Assert startAt is called                                                                  | [startAt](https://googleapis.dev/nodejs/firestore/latest/Query.html#startAt)                          |
+| `mockWithConverter` | Assert withConverter is called                                                            | [withConverter](https://firebase.google.com/docs/reference/js/firebase.firestore.Query#withconverter) |
 
 #### [Firestore.FieldValue](https://googleapis.dev/nodejs/firestore/latest/FieldValue.html)
 

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -21,6 +21,7 @@ const {
   mockDoc,
   mockCollection,
   mockWithConverter,
+  FakeFirestore,
 } = require('../mocks/firestore');
 
 describe('we can start a firebase application', () => {
@@ -302,31 +303,46 @@ describe('we can start a firebase application', () => {
       test('single document', async () => {
         const db = this.firebase.firestore();
 
-        await db.doc('characters/homer').withConverter(converter).get();
+        const recordDoc = db.doc('cities/la').withConverter(converter);
 
-        expect(mockDoc).toHaveBeenCalledWith('characters/homer');
+        expect(mockDoc).toHaveBeenCalledWith('cities/la');
         expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(recordDoc).toBeInstanceOf(FakeFirestore.DocumentReference);
+
+        const record = await recordDoc.get();
         expect(mockGet).toHaveBeenCalled();
+        expect(record).toHaveProperty('id', 'la');
+        expect(record.data).toBeInstanceOf(Function);
       });
 
       test('single undefined document', async () => {
         const db = this.firebase.firestore();
 
-        await db.collection('characters').withConverter(converter).doc().get();
+        const recordDoc = db.collection('cities').withConverter(converter).doc();
 
-        expect(mockCollection).toHaveBeenCalledWith('characters');
+        expect(mockCollection).toHaveBeenCalledWith('cities');
         expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(mockDoc).toHaveBeenCalledWith('abc123');
+        expect(recordDoc).toBeInstanceOf(FakeFirestore.DocumentReference);
+
+        const record = await recordDoc.get();
         expect(mockGet).toHaveBeenCalled();
+        expect(record).toHaveProperty('id', 'abc123');
+        expect(record.data).toBeInstanceOf(Function);
       });
 
       test('multiple documents', async () => {
         const db = this.firebase.firestore();
 
-        await db.collection('characters').withConverter(converter).get();
+        const recordsCol = db.collection('cities').withConverter(converter);
 
-        expect(mockCollection).toHaveBeenCalledWith('characters');
+        expect(mockCollection).toHaveBeenCalledWith('cities');
         expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(recordsCol).toBeInstanceOf(FakeFirestore.CollectionReference);
+
+        const records = await recordsCol.get();
         expect(mockGet).toHaveBeenCalled();
+        expect(records).toHaveProperty('docs', expect.any(Array));
       });
     });
   });

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -17,6 +17,9 @@ const {
   mockBatchSet,
   mockSettings,
   mockOnSnapShot,
+  mockDoc,
+  mockCollection,
+  mockWithConverter,
 } = require('../mocks/firestore');
 
 describe('we can start a firebase application', () => {
@@ -281,6 +284,43 @@ describe('we can start a firebase application', () => {
       expect(unsubscribe).toBeInstanceOf(Function);
       expect(mockWhere).toHaveBeenCalled();
       expect(mockOnSnapShot).toHaveBeenCalled();
+    });
+
+    describe('withConverter', () => {
+      const converter = {
+        fromFirestore: () => {},
+        toFirestore: () => {},
+      };
+
+      test('single document', async () => {
+        const db = this.firebase.firestore();
+
+        await db.doc('characters/homer').withConverter(converter).get();
+
+        expect(mockDoc).toHaveBeenCalledWith('characters/homer');
+        expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(mockGet).toHaveBeenCalled();
+      });
+
+      test('single undefined document', async () => {
+        const db = this.firebase.firestore();
+
+        await db.collection('characters').withConverter(converter).doc().get();
+
+        expect(mockCollection).toHaveBeenCalledWith('characters');
+        expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(mockGet).toHaveBeenCalled();
+      });
+
+      test('multiple documents', async () => {
+        const db = this.firebase.firestore();
+
+        await db.collection('characters').withConverter(converter).get();
+
+        expect(mockCollection).toHaveBeenCalledWith('characters');
+        expect(mockWithConverter).toHaveBeenCalledWith(converter);
+        expect(mockGet).toHaveBeenCalled();
+      });
     });
   });
 });

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -4,6 +4,7 @@ const {
   mockGet,
   mockWhere,
   mockOffset,
+  mockWithConverter,
   FakeFirestore,
 } = require('../mocks/firestore');
 const { mockFirebase } = require('firestore-jest-mock');
@@ -120,5 +121,18 @@ describe('test', () => {
     expect(mockCollection).toHaveBeenCalledWith('animals');
     expect(mockGet).toHaveBeenCalled();
     expect(mockOffset).toHaveBeenCalledWith(2);
+  });
+
+  test('it can convert query', () => {
+    const converter = {
+      fromFirestore: () => {},
+      toFirestore: () => {},
+    };
+
+    db.collection('animals').withConverter(converter).get();
+
+    expect(mockCollection).toHaveBeenCalledWith('animals');
+    expect(mockWithConverter).toHaveBeenCalledWith(converter);
+    expect(mockGet).toHaveBeenCalled();
   });
 });

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -4,7 +4,6 @@ const {
   mockGet,
   mockWhere,
   mockOffset,
-  mockWithConverter,
   FakeFirestore,
 } = require('../mocks/firestore');
 const { mockFirebase } = require('firestore-jest-mock');
@@ -121,18 +120,5 @@ describe('test', () => {
     expect(mockCollection).toHaveBeenCalledWith('animals');
     expect(mockGet).toHaveBeenCalled();
     expect(mockOffset).toHaveBeenCalledWith(2);
-  });
-
-  test('it can convert query', () => {
-    const converter = {
-      fromFirestore: () => {},
-      toFirestore: () => {},
-    };
-
-    db.collection('animals').withConverter(converter).get();
-
-    expect(mockCollection).toHaveBeenCalledWith('animals');
-    expect(mockWithConverter).toHaveBeenCalledWith(converter);
-    expect(mockGet).toHaveBeenCalled();
   });
 });

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -251,7 +251,8 @@ FakeFirestore.DocumentReference = class {
   }
 
   withConverter() {
-    return this.query.withConverter(...arguments);
+    query.mocks.mockWithConverter(...arguments);
+    return this;
   }
 };
 

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -249,6 +249,10 @@ FakeFirestore.DocumentReference = class {
   startAt() {
     return this.query.startAt(...arguments);
   }
+
+  withConverter() {
+    return this.query.withConverter(...arguments);
+  }
 };
 
 /*

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -8,6 +8,7 @@ const mockOffset = jest.fn();
 const mockStartAfter = jest.fn();
 const mockStartAt = jest.fn();
 const mockQueryOnSnapshot = jest.fn();
+const mockWithConverter = jest.fn();
 
 class Query {
   constructor(collectionName, firestore) {
@@ -69,6 +70,10 @@ class Query {
     return mockStartAt(...arguments) || this;
   }
 
+  withConverter() {
+    return mockWithConverter(...arguments) || this;
+  }
+
   onSnapshot() {
     mockQueryOnSnapshot(...arguments);
     const [callback, errorCallback] = arguments;
@@ -96,5 +101,6 @@ module.exports = {
     mockStartAfter,
     mockStartAt,
     mockQueryOnSnapshot,
+    mockWithConverter,
   },
 };


### PR DESCRIPTION
# Description

Initial work for adding support for withConverter, issue created with discussion needed

## Related issues

#77 

## How to test

```
firestore.doc('data/1').withConverter()
firestore.collection('data').withConverter()
firestore.collection('data').doc('1').withConverter()
```
Using these calls should not throw error with function not found
