### PR TITLE
return array from commit promise

### DIFF
--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -213,7 +213,8 @@ describe('we can start a firebase application', () => {
       batch.delete(laRef);
 
       // Commit the batch
-      return batch.commit().then(function() {
+      return batch.commit().then(function(result) {
+        expect(result).toBeInstanceOf(Array);
         expect(mockBatch).toHaveBeenCalled();
         expect(mockBatchDelete).toHaveBeenCalledWith(laRef);
         expect(mockBatchUpdate).toHaveBeenCalledWith(sfRef, { population: 1000000 });
@@ -318,7 +319,10 @@ describe('we can start a firebase application', () => {
       test('single undefined document', async () => {
         const db = this.firebase.firestore();
 
-        const recordDoc = db.collection('cities').withConverter(converter).doc();
+        const recordDoc = db
+          .collection('cities')
+          .withConverter(converter)
+          .doc();
 
         expect(mockCollection).toHaveBeenCalledWith('cities');
         expect(mockWithConverter).toHaveBeenCalledWith(converter);

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -64,7 +64,7 @@ class FakeFirestore {
       },
       commit() {
         mockBatchCommit(...arguments);
-        return Promise.resolve();
+        return Promise.resolve([]);
       },
     };
   }


### PR DESCRIPTION
# Description

<!-- Write a brief description of the changes introduced by this PR -->
As documented here: https://googleapis.dev/nodejs/firestore/latest/WriteBatch.html#commit
The promise return by `commit` for batches resolves to an array. We don't have to reproduce the full behavior, but we should at least return the correct type

## Related issues
Fixes https://github.com/Upstatement/firestore-jest-mock/issues/80
