### PR TITLE
add options hash to mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Small, easy to grok pull requests are welcome, but please note that there is no 
     - [What would you want to test?](#what-would-you-want-to-test)
     - [Don't forget to reset your mocks](#dont-forget-to-reset-your-mocks)
       - [I wrote a where clause, but all the records were returned!](#i-wrote-a-where-clause-but-all-the-records-were-returned)
+    - [Additional options](#additional-options)
+      - [includeIdsInData](#includeidsindata)
     - [Functions you can test](#functions-you-can-test)
       - [Firestore](#firestore)
       - [Firestore.Query](#firestorequery)
@@ -136,8 +138,9 @@ test('testing stuff', () => {
     });
 });
 ```
-*Note: Authentication with `@google-cloud/firestore` is not handled in the same way as with `firebase`.
-The `Auth` module is not available for `@google-cloud/firestore` compatibility.*
+
+_Note: Authentication with `@google-cloud/firestore` is not handled in the same way as with `firebase`.
+The `Auth` module is not available for `@google-cloud/firestore` compatibility._
 
 ### Subcollections
 
@@ -290,6 +293,25 @@ The `where` clause in the mocked Firestore will not actually filter the data at 
 We are not recreating Firestore in this mock, just exposing an API that allows us to write assertions.
 It is also not the job of the developer (you) to test that Firestore filtered the data appropriately.
 Your application doesn't double-check Firestore's response -- it trusts that it's always correct!
+
+### Additional options
+
+The default state of this mock is meant for basic testing that should cover most everyone.  
+However, you can pass an `options` object to the mock to overwrite some default behavior.
+
+```js
+const options = {
+  includeIdsInData: true,
+};
+
+mockFirebase(database, options);
+```
+
+#### includeIdsInData
+
+By default, id's are not returned with the document's data.
+Although you can declare an id when setting up your fake database, it will not be returned with `data()` as that is not the default behavior of firebase.
+However, a common practice for firestore users is to manually write an `id` property to their documents, allowing them to query `collectionGroup` by id.
 
 ### Functions you can test
 

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -104,6 +104,7 @@ describe('we can start a firebase application', () => {
           querySnapshot.forEach(doc => {
             expect(doc.exists).toBe(true);
             expect(doc.data()).toBeTruthy();
+            expect(doc.data().id).toBeFalsy();
           });
         });
     });

--- a/__tests__/options.test.js
+++ b/__tests__/options.test.js
@@ -1,0 +1,58 @@
+const { FakeFirestore } = require('firestore-jest-mock');
+const { mockCollection, mockDoc } = require('firestore-jest-mock/mocks/firestore');
+
+describe('Firestore options', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const database = {
+    characters: [
+      {
+        id: 'homer',
+        name: 'Homer',
+        occupation: 'technician',
+        address: { street: '742 Evergreen Terrace' },
+      },
+      { id: 'krusty', name: 'Krusty', occupation: 'clown' },
+      {
+        id: 'bob',
+        name: 'Bob',
+        occupation: 'insurance agent',
+        _collections: {
+          family: [
+            { id: 'violet', name: 'Violet', relation: 'daughter' },
+            { id: 'dash', name: 'Dash', relation: 'son' },
+            { id: 'jackjack', name: 'Jackjack', relation: 'son' },
+            { id: 'helen', name: 'Helen', relation: 'wife' },
+          ],
+        },
+      },
+    ],
+  };
+
+  const options = {
+    includeIdsInData: true,
+  };
+
+  const db = new FakeFirestore(database, options);
+
+  describe('Single records versus queries', () => {
+    test('it can fetch a single record', async () => {
+      expect.assertions(7);
+      const record = await db
+        .collection('characters')
+        .doc('krusty')
+        .get();
+      expect(mockCollection).toHaveBeenCalledWith('characters');
+      expect(mockDoc).toHaveBeenCalledWith('krusty');
+      expect(record.exists).toBe(true);
+      expect(record.id).toBe('krusty');
+      const data = record.data();
+      expect(data).toHaveProperty('name', 'Krusty');
+      expect(data).toHaveProperty('occupation', 'clown');
+      expect(data).toHaveProperty('id', 'krusty');
+    });
+  });
+});

--- a/mocks/firebase.d.ts
+++ b/mocks/firebase.d.ts
@@ -15,6 +15,10 @@ export interface StubOverrides {
   currentUser?: unknown; // User, to be defined later
 }
 
+export interface StubOptions {
+  includeIdsInData?: boolean;
+}
+
 export interface FirebaseMock {
   initializeApp: jest.Mock;
   credential: {
@@ -24,7 +28,7 @@ export interface FirebaseMock {
   firestore(): unknown; // Firestore, to be defined later
 }
 
-export const firebaseStub: (overrides?: StubOverrides) => FirebaseMock;
-export const mockFirebase: (overrides?: StubOverrides) => void;
+export const firebaseStub: (overrides?: StubOverrides, options?: StubOptions) => FirebaseMock;
+export const mockFirebase: (overrides?: StubOverrides, options?: StubOptions) => void;
 export const mockInitializeApp: jest.Mock;
 export const mockCert: jest.Mock;

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -1,12 +1,14 @@
 const mockInitializeApp = jest.fn();
 const mockCert = jest.fn();
 
-const firebaseStub = overrides => {
+const defaultOptions = require('./helpers/defaultMockOptions');
+
+const firebaseStub = (overrides, options = defaultOptions) => {
   const { FakeFirestore, FakeAuth } = require('firestore-jest-mock');
 
   // Prepare namespaced classes
   function firestoreConstructor() {
-    return new FakeFirestore(overrides.database);
+    return new FakeFirestore(overrides.database, options);
   }
 
   firestoreConstructor.Query = FakeFirestore.Query;
@@ -32,15 +34,15 @@ const firebaseStub = overrides => {
   };
 };
 
-const mockFirebase = (overrides = {}) => {
-  mockModuleIfFound('firebase', overrides);
-  mockModuleIfFound('firebase-admin', overrides);
+const mockFirebase = (overrides = {}, options = defaultOptions) => {
+  mockModuleIfFound('firebase', overrides, options);
+  mockModuleIfFound('firebase-admin', overrides, options);
 };
 
-function mockModuleIfFound(moduleName, overrides) {
+function mockModuleIfFound(moduleName, overrides, options) {
   try {
     require.resolve(moduleName);
-    jest.doMock(moduleName, () => firebaseStub(overrides));
+    jest.doMock(moduleName, () => firebaseStub(overrides, options));
   } catch (e) {
     // eslint-disable-next-line no-console
     console.info(`Module ${moduleName} not found, mocking skipped.`);

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -27,9 +27,10 @@ const buildDocFromHash = require('./helpers/buildDocFromHash');
 const buildQuerySnapShot = require('./helpers/buildQuerySnapShot');
 
 class FakeFirestore {
-  constructor(stubbedDatabase = {}) {
+  constructor(stubbedDatabase = {}, options = {}) {
     this.database = stubbedDatabase;
     this.query = new query.Query('', this);
+    this.options = options;
   }
 
   set collectionName(collectionName) {

--- a/mocks/googleCloudFirestore.js
+++ b/mocks/googleCloudFirestore.js
@@ -1,10 +1,11 @@
+const defaultOptions = require('./helpers/defaultMockOptions');
 
-const firestoreStub = overrides => {
+const firestoreStub = (overrides, options = defaultOptions) => {
   const { FakeFirestore } = require('firestore-jest-mock');
 
   class Firestore extends FakeFirestore {
     constructor() {
-      super(overrides.database);
+      super(overrides.database, options);
     }
   }
   return {
@@ -18,14 +19,14 @@ const firestoreStub = overrides => {
   };
 };
 
-const mockGoogleCloudFirestore = (overrides = {}) => {
-  mockModuleIfFound('@google-cloud/firestore', overrides);
+const mockGoogleCloudFirestore = (overrides = {}, options = defaultOptions) => {
+  mockModuleIfFound('@google-cloud/firestore', overrides, options);
 };
 
-function mockModuleIfFound(moduleName, overrides) {
+function mockModuleIfFound(moduleName, overrides, options) {
   try {
     require.resolve(moduleName);
-    jest.doMock(moduleName, () => firestoreStub(overrides));
+    jest.doMock(moduleName, () => firestoreStub(overrides, options));
   } catch (e) {
     // eslint-disable-next-line no-console
     console.info(`Module ${moduleName} not found, mocking skipped.`);

--- a/mocks/helpers/buildDocFromHash.js
+++ b/mocks/helpers/buildDocFromHash.js
@@ -14,7 +14,9 @@ module.exports = function buildDocFromHash(hash = {}, id = 'abc123') {
         return undefined;
       }
       const copy = { ...hash };
-      delete copy.id;
+      if (!hash._ref.parent.firestore.options.includeIdsInData) {
+        delete copy.id;
+      }
       delete copy._collections;
       delete copy._ref;
       return copy;

--- a/mocks/helpers/defaultMockOptions.js
+++ b/mocks/helpers/defaultMockOptions.js
@@ -1,0 +1,3 @@
+module.exports = {
+  includeIdsInData: false,
+};


### PR DESCRIPTION
# Description

<!-- Write a brief description of the changes introduced by this PR -->
Adds the ability to pass options to the mock, allowing you to include id's in your document's data.

## Related issues

Fixes: https://github.com/Upstatement/firestore-jest-mock/issues/68

Also adds the ability for future options, which I think can be a good stop-gap for https://github.com/Upstatement/firestore-jest-mock/pull/70

## How to test

Pass a second param to `mockFirebase` as your "options."
You can set `includeIdsInData` to have `doc.data()` return the id of the document (custom behavior).
