### PR TITLE
add transaction create method

### DIFF
--- a/__tests__/transaction.test.js
+++ b/__tests__/transaction.test.js
@@ -11,6 +11,7 @@ const {
   mockGetTransaction,
   mockGetAll,
   mockGetAllTransaction,
+  mockCreateTransaction,
 } = require('firestore-jest-mock/mocks/firestore');
 
 describe('Transactions', () => {
@@ -130,5 +131,23 @@ describe('Transactions', () => {
       expect(mockGetAll).toHaveBeenCalled();
     });
     expect(mockGetAllTransaction).toHaveBeenCalled();
+  });
+
+  test('mockCreateTransaction is accessible', async () => {
+    expect.assertions(2);
+    expect(mockCreateTransaction).not.toHaveBeenCalled();
+    // Example from documentation
+    // https://googleapis.dev/nodejs/firestore/latest/Transaction.html#create-examples
+
+    await db.runTransaction(async transaction => {
+      const documentRef = db.doc('col/doc');
+      return transaction.get(documentRef).then(doc => {
+        if (!doc.exists) {
+          transaction.create(documentRef, { foo: 'bar' });
+        }
+      });
+    });
+
+    expect(mockCreateTransaction).toHaveBeenCalled();
   });
 });

--- a/mocks/transaction.js
+++ b/mocks/transaction.js
@@ -4,6 +4,7 @@ const mockGetTransaction = jest.fn();
 const mockSetTransaction = jest.fn();
 const mockUpdateTransaction = jest.fn();
 const mockDeleteTransaction = jest.fn();
+const mockCreateTransaction = jest.fn();
 
 class Transaction {
   getAll(...refsOrReadOptions) {
@@ -40,6 +41,12 @@ class Transaction {
     ref.delete();
     return this;
   }
+
+  create(ref, options) {
+    mockCreateTransaction(...arguments);
+    ref.set(options);
+    return this;
+  }
 }
 
 module.exports = {
@@ -51,5 +58,6 @@ module.exports = {
     mockSetTransaction,
     mockUpdateTransaction,
     mockDeleteTransaction,
+    mockCreateTransaction,
   },
 };


### PR DESCRIPTION
# Description

Adds the `create` method a firestore transaction, as documented here:
https://googleapis.dev/nodejs/firestore/latest/Transaction.html#create-examples

## Related issues
Fixes https://github.com/Upstatement/firestore-jest-mock/issues/84

## How to test
Can you run a transaction with the `create` method and assert it was called?
