### PR TITLE
add mutable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Small, easy to grok pull requests are welcome, but please note that there is no 
       - [I wrote a where clause, but all the records were returned!](#i-wrote-a-where-clause-but-all-the-records-were-returned)
     - [Additional options](#additional-options)
       - [includeIdsInData](#includeidsindata)
+      - [mutable](#mutable)
     - [Functions you can test](#functions-you-can-test)
       - [Firestore](#firestore)
       - [Firestore.Query](#firestorequery)
@@ -302,6 +303,7 @@ However, you can pass an `options` object to the mock to overwrite some default 
 ```js
 const options = {
   includeIdsInData: true,
+  mutable: true,
 };
 
 mockFirebase(database, options);
@@ -312,6 +314,20 @@ mockFirebase(database, options);
 By default, id's are not returned with the document's data.
 Although you can declare an id when setting up your fake database, it will not be returned with `data()` as that is not the default behavior of firebase.
 However, a common practice for firestore users is to manually write an `id` property to their documents, allowing them to query `collectionGroup` by id.
+
+#### mutable
+
+_Warning: Thar be dragons_
+
+By default, the mock database you set up is immutable.
+This means it doesn't update, even when you call things like `set` or `add`, as the result isn't typically important for your tests.
+If you need your tests to update the mock database, you can set `mutable` to true when calling `mockFirebase`.
+Calling `.set()` on a document or collection would update the mock database you created.
+This can make your tests less predictable, as they may need to be run in the same order.
+
+Use with caution.
+
+_Note: not all APIs that update the database are supported yet. PR's welcome!_
 
 ### Functions you can test
 

--- a/mocks/helpers/defaultMockOptions.js
+++ b/mocks/helpers/defaultMockOptions.js
@@ -1,3 +1,4 @@
 module.exports = {
   includeIdsInData: false,
+  mutable: false,
 };


### PR DESCRIPTION
# Description

In preparation for https://github.com/Upstatement/firestore-jest-mock/pull/70, this PR adds a new option to our `mockFirebase` option.

If users want their mocked database to update during their tests, they can set this flag.  This also updates the README to spell out why it defaults to `false` and explain the downside of mutating your test stub.

## How to test

Just adds the options for use in another PR.
