### PR TITLE
Add types to supporting files

### DIFF
--- a/mocks/fieldValue.d.ts
+++ b/mocks/fieldValue.d.ts
@@ -1,0 +1,21 @@
+type FieldValueType = 'arrayUnion' | 'arrayRemove' | 'increment' | 'serverTimestamp' | 'delete';
+
+export class FieldValue {
+  constructor(type: FieldValueType, value: unknown);
+
+  isEqual(other: FieldValue): boolean;
+
+  static arrayUnion(elements?: Array<unknown>): FieldValue;
+  static arrayRemove(elements: Array<unknown>): FieldValue;
+  static increment(amount?: number): FieldValue;
+  static serverTimestamp(): FieldValue;
+  static delete(): FieldValue;
+}
+
+export const mocks: {
+  mockArrayUnionFieldValue: jest.Mock;
+  mockArrayRemoveFieldValue: jest.Mock;
+  mockDeleteFieldValue: jest.Mock;
+  mockIncrementFieldValue: jest.Mock;
+  mockServerTimestampFieldValue: jest.Mock;
+};

--- a/mocks/firebase.d.ts
+++ b/mocks/firebase.d.ts
@@ -12,7 +12,7 @@ export type FakeFirestoreDocumentData = Record<string, unknown>;
 
 export interface StubOverrides {
   database?: DatabaseCollections;
-  currentUser?: unknown; // User, to be defined later
+  currentUser?: unknown; // TODO: User, to be defined later
 }
 
 export interface StubOptions {
@@ -24,8 +24,8 @@ export interface FirebaseMock {
   credential: {
     cert: jest.Mock;
   };
-  auth(): unknown; // Auth, to be defined later
-  firestore(): unknown; // Firestore, to be defined later
+  auth(): unknown; // TODO: Auth, to be defined later
+  firestore(): unknown; // TODO: FakeFirestore, to be defined later
 }
 
 export const firebaseStub: (overrides?: StubOverrides, options?: StubOptions) => FirebaseMock;

--- a/mocks/helpers/buildDocFromHash.d.ts
+++ b/mocks/helpers/buildDocFromHash.d.ts
@@ -1,0 +1,22 @@
+import type { FakeFirestore } from '../firestore';
+
+export type DocumentData = { [field: string]: unknown };
+
+export interface DocumentHash extends DocumentData {
+  id?: string;
+  _collections: unknown; // TODO: FakeFirestore subcollections, to be defined later
+  _ref: typeof FakeFirestore.DocumentReference;
+}
+
+export interface MockedDocument<T = DocumentData> {
+  exists: boolean;
+  id: string;
+  ref: typeof FakeFirestore.DocumentReference;
+  metadata: {
+    hasPendingWrites: 'Server';
+  };
+  data(): T | undefined;
+  get(fieldPath: string): unknown;
+}
+
+export default function buildDocFromHash(hash?: DocumentHash, id?: string): MockedDocument;

--- a/mocks/helpers/buildQuerySnapShot.d.ts
+++ b/mocks/helpers/buildQuerySnapShot.d.ts
@@ -1,0 +1,18 @@
+import type { MockedDocument, DocumentHash } from './buildDocFromHash';
+
+export interface MockedQuerySnapshot<Doc = MockedDocument> {
+  empty: boolean;
+  size: number;
+  docs: Array<Doc>;
+  forEach(callbackfn: (value: Doc, index: number, array: Doc[]) => void): void;
+  docChanges(): {
+    forEach(callbackfn: () => void): void
+  };
+}
+
+/**
+ * Builds a query result from the given array of record objects.
+ *
+ * @param requestedRecords
+ */
+export default function buildQuerySnapShot(requestedRecords: Array<DocumentHash>): MockedQuerySnapshot;

--- a/mocks/helpers/buildQuerySnapShot.d.ts
+++ b/mocks/helpers/buildQuerySnapShot.d.ts
@@ -4,10 +4,8 @@ export interface MockedQuerySnapshot<Doc = MockedDocument> {
   empty: boolean;
   size: number;
   docs: Array<Doc>;
-  forEach(callbackfn: (value: Doc, index: number, array: Doc[]) => void): void;
-  docChanges(): {
-    forEach(callbackfn: () => void): void
-  };
+  forEach(callbackfn: (value: Doc, index: number, array: Array<Doc>) => void): void;
+  docChanges(): Array<never>;
 }
 
 /**

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -1,10 +1,5 @@
 const buildDocFromHash = require('./buildDocFromHash');
 
-/**
- * Builds a query result from the given array of record objects.
- *
- * @param {*[]} requestedRecords
- */
 module.exports = function buildQuerySnapShot(requestedRecords) {
   const multipleRecords = requestedRecords.filter(rec => !!rec);
   const docs = multipleRecords.map(buildDocFromHash);

--- a/mocks/helpers/defaultMockOptions.d.ts
+++ b/mocks/helpers/defaultMockOptions.d.ts
@@ -1,0 +1,1 @@
+export const includeIdsInData: boolean;

--- a/mocks/query.d.ts
+++ b/mocks/query.d.ts
@@ -1,0 +1,29 @@
+import type { FakeFirestore } from './firestore';
+import type { MockedQuerySnapshot } from './helpers/buildQuerySnapShot';
+
+export class Query {
+  constructor(collectionName: string, firestore: typeof FakeFirestore);
+
+  get(): Promise<MockedQuerySnapshot>;
+
+  where(): Query;
+  offset(): Query;
+  limit(): Query;
+  orderBy(): Query;
+  startAfter(): Query;
+  startAt(): Query;
+  withConverter(): Query;
+  onSnapshot(): () => void;
+}
+
+export const mocks: {
+  mockGet: jest.Mock,
+  mockWhere: jest.Mock,
+  mockLimit: jest.Mock,
+  mockOrderBy: jest.Mock,
+  mockOffset: jest.Mock,
+  mockStartAfter: jest.Mock,
+  mockStartAt: jest.Mock,
+  mockQueryOnSnapshot: jest.Mock,
+  mockWithConverter: jest.Mock,
+};

--- a/mocks/timestamp.d.ts
+++ b/mocks/timestamp.d.ts
@@ -1,0 +1,20 @@
+export class Timestamp {
+  constructor(seconds: number, nanoseconds: number);
+
+  isEqual(other: Timestamp): boolean;
+  toDate(): Date;
+  toMillis(): number;
+  valueOf(): string;
+
+  static fromDate(date: Date): Timestamp;
+  static fromMillis(millis: number): Timestamp;
+  static now(): Timestamp;
+}
+
+export const mocks: {
+  mockTimestampToDate: jest.Mock;
+  mockTimestampToMillis: jest.Mock;
+  mockTimestampFromDate: jest.Mock;
+  mockTimestampFromMillis: jest.Mock;
+  mockTimestampNow: jest.Mock;
+};

--- a/mocks/transaction.d.ts
+++ b/mocks/transaction.d.ts
@@ -1,0 +1,21 @@
+import type { Query } from './query';
+import type { MockedQuerySnapshot } from './helpers/buildQuerySnapShot';
+
+export class Transaction {
+  getAll(...refsOrReadOptions: Array<Query | Record<string, never>>): Promise<Array<MockedQuerySnapshot>>;
+  get(ref: Query): Promise<MockedQuerySnapshot>;
+  set(ref: Query): Transaction;
+  update(ref: Query): Transaction;
+  delete(ref: Query): Transaction;
+  create(ref: Query, options: unknown): Transaction;
+}
+
+export const mocks: {
+  mockGetAll: jest.Mock;
+  mockGetAllTransaction: jest.Mock;
+  mockGetTransaction: jest.Mock;
+  mockSetTransaction: jest.Mock;
+  mockUpdateTransaction: jest.Mock;
+  mockDeleteTransaction: jest.Mock;
+  mockCreateTransaction: jest.Mock;
+};


### PR DESCRIPTION
# Description

More TypeScript typings. This branch adds typings to more of our internal modules. What I'm looking for here is a confirmation that the type declarations presented here are where we wanna go in the future.

My next PR would add typings to the rest of the app, which should expose all relevant mock functions to TypeScript.

## How to test

There is nothing yet to test. All changes are additive to internal type files.
