### PR TITLE
docChanges returns an array

### DIFF
--- a/__tests__/full-setup-google-cloud-firestore.test.js
+++ b/__tests__/full-setup-google-cloud-firestore.test.js
@@ -196,7 +196,8 @@ describe('we can start a firestore application', () => {
     test('onSnapshot single doc', async () => {
       const firestore = new this.Firestore();
 
-      firestore.collection('cities')
+      firestore
+        .collection('cities')
         .doc('LA')
         .onSnapshot(doc => {
           expect(doc).toHaveProperty('data');
@@ -212,7 +213,8 @@ describe('we can start a firestore application', () => {
     test('onSnapshot can work with options', async () => {
       const firestore = new this.Firestore();
 
-      firestore.collection('cities')
+      firestore
+        .collection('cities')
         .doc('LA')
         .onSnapshot(
           {
@@ -246,7 +248,7 @@ describe('we can start a firestore application', () => {
           expect(querySnapshot.docChanges).toBeInstanceOf(Function);
           expect(querySnapshot.docs).toBeInstanceOf(Array);
 
-          expect(querySnapshot.docChanges().forEach).toBeInstanceOf(Function);
+          expect(querySnapshot.docChanges()).toBeInstanceOf(Array);
         });
 
       await flushPromises();

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -286,7 +286,7 @@ describe('we can start a firebase application', () => {
           expect(querySnapshot.docChanges).toBeInstanceOf(Function);
           expect(querySnapshot.docs).toBeInstanceOf(Array);
 
-          expect(querySnapshot.docChanges().forEach).toBeInstanceOf(Function);
+          expect(querySnapshot.docChanges()).toBeInstanceOf(Array);
         });
 
       await flushPromises();

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -17,13 +17,7 @@ module.exports = function buildQuerySnapShot(requestedRecords) {
       docs.forEach(callback);
     },
     docChanges() {
-      return {
-        forEach(callback) {
-          // eslint-disable-next-line no-console
-          console.info('Firestore jest mock does not currently support tracking changes');
-          callback();
-        },
-      };
+      return [];
     },
   };
 };


### PR DESCRIPTION
# Description

`docChanges` returns an array, rather than an object with a `forEach` (like a document) as listed here:
https://firebase.google.com/docs/reference/js/firebase.firestore.QuerySnapshot#docchanges

This PR changes it to return just an empty array for now.

## Related issues

Fixes https://github.com/Upstatement/firestore-jest-mock/issues/89

## How to test

Write an assertion that assumes the value from `docChanges` is an array
