### PR TITLE
fix: export mockGoogleCloudFirestore on type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
 export { FakeFirestore } from './mocks/firestore';
 export { FakeAuth } from './mocks/auth';
 export { mockFirebase } from './mocks/firebase';
+export { mockGoogleCloudFirestore } from './mocks/googleCloudFirestore';


### PR DESCRIPTION
# Description

Installed this library on a TypeScript project today and when importing mockGoogleCloudFirestore I got a TS error explaining that the module does not have an exported member with that name. This PR adds it to the index.d.ts file.

