### PR TITLE
Support Timestamps in where queries + ReadOptions for getAll

### DIFF
--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -21,6 +21,7 @@ describe('Queries', () => {
             food: ['banana', 'mango'],
             foodCount: 1,
             foodEaten: [500, 20],
+            createdAt: new FakeFirestore.Timestamp(1628939119, 0),
           },
           {
             id: 'elephant',
@@ -30,6 +31,7 @@ describe('Queries', () => {
             food: ['banana', 'peanut'],
             foodCount: 0,
             foodEaten: [0, 500],
+            createdAt: new FakeFirestore.Timestamp(1628939129, 0),
           },
           {
             id: 'chicken',
@@ -39,6 +41,7 @@ describe('Queries', () => {
             food: ['leaf', 'nut', 'ant'],
             foodCount: 4,
             foodEaten: [80, 20, 16],
+            createdAt: new FakeFirestore.Timestamp(1628939139, 0),
             _collections: {
               foodSchedule: [
                 {
@@ -60,6 +63,7 @@ describe('Queries', () => {
             food: ['leaf', 'bread'],
             foodCount: 2,
             foodEaten: [80, 12],
+            createdAt: new FakeFirestore.Timestamp(1628939149, 0),
             _collections: {
               foodSchedule: [
                 {
@@ -168,6 +172,27 @@ describe('Queries', () => {
     const pogoStick = noFood.docs[0];
     expect(pogoStick).toBeDefined();
     expect(pogoStick).toHaveProperty('id', 'pogo-stick');
+  });
+
+  test('it can query date values for equality', async () => {
+    const elephant = await db
+      .collection('animals')
+      .where('createdAt', '==', new Date(1628939129 * 1000))
+      .get();
+
+    expect(elephant).toHaveProperty('size', 1);
+    expect(elephant.docs[0].id).toEqual('elephant');
+  });
+
+  test('it can query date values for greater than condition', async () => {
+    const res = await db
+      .collection('animals')
+      .where('createdAt', '>', new Date(1628939129 * 1000))
+      .get();
+
+    expect(res).toHaveProperty('size', 2);
+    expect(res.docs[0].id).toEqual('chicken');
+    expect(res.docs[1].id).toEqual('ant');
   });
 
   test('it can query multiple documents', async () => {

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -46,9 +46,12 @@ class FakeFirestore {
     return this.query.collectionName;
   }
 
-  getAll() {
+  getAll(...params) {
+    //Strip ReadOptions object
+    params = params.filter(arg => arg instanceof FakeFirestore.DocumentReference);
+    
     return Promise.all(
-      transaction.mocks.mockGetAll(...arguments) || [...arguments].map(r => r.get()),
+      transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()),
     );
   }
 

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -174,7 +174,7 @@ function _recordsNotEqualToValue(records, key, value) {
     if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() != value;
     }
-    String(record[key]) !== String(value)
+    return String(record[key]) !== String(value);
   });
 }
 

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -109,7 +109,9 @@ function _shouldCompareNumerically(a, b) {
 function _shouldCompareTimestamp(a, b) {
   //We check whether toMillis method exists to support both Timestamp mock and Firestore Timestamp object
   //B is expected to be Date, not Timestamp, just like Firestore does
-  return typeof a === 'object' && a !== null && typeof a.toMillis === 'function' && b instanceof Date;
+  return (
+    typeof a === 'object' && a !== null && typeof a.toMillis === 'function' && b instanceof Date
+  );
 }
 
 /**
@@ -123,7 +125,7 @@ function _recordsLessThanValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] < value;
     }
-	  if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() < value;
     }
     return String(record[key]) < String(value);
@@ -137,11 +139,11 @@ function _recordsLessThanValue(records, key, value) {
  * @returns {Array<DocumentHash>}
  */
 function _recordsLessThanOrEqualToValue(records, key, value) {
-  return _recordsWithNonNullKey(records, key).filter(record => {	  
+  return _recordsWithNonNullKey(records, key).filter(record => {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] <= value;
     }
-	  if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() <= value;
     }
     return String(record[key]) <= String(value);
@@ -157,7 +159,8 @@ function _recordsLessThanOrEqualToValue(records, key, value) {
 function _recordsEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     if (_shouldCompareTimestamp(record[key], value)) {
-      return record[key].toMillis() == value;
+      //NOTE: for equality, we must compare numbers!
+      return record[key].toMillis() === value.getTime();
     }
     return String(record[key]) === String(value);
   });
@@ -172,7 +175,8 @@ function _recordsEqualToValue(records, key, value) {
 function _recordsNotEqualToValue(records, key, value) {
   return _recordsWithKey(records, key).filter(record => {
     if (_shouldCompareTimestamp(record[key], value)) {
-      return record[key].toMillis() != value;
+      //NOTE: for equality, we must compare numbers!
+      return record[key].toMillis() !== value.getTime();
     }
     return String(record[key]) !== String(value);
   });
@@ -189,7 +193,7 @@ function _recordsGreaterThanOrEqualToValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] >= value;
     }
-	  if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() >= value;
     }
     return String(record[key]) >= String(value);
@@ -207,7 +211,7 @@ function _recordsGreaterThanValue(records, key, value) {
     if (_shouldCompareNumerically(record[key], value)) {
       return record[key] > value;
     }
-	  if (_shouldCompareTimestamp(record[key], value)) {
+    if (_shouldCompareTimestamp(record[key], value)) {
       return record[key].toMillis() > value;
     }
     return String(record[key]) > String(value);


### PR DESCRIPTION
Sorry, I kind of messed up the branches, this PR contains 2 small fixes.

# Support Timestamps in where queries
Currently filtering Timestamps does not work at all because they are compared as strings, this pr adds support for comparing with Date objects.

# Support ReadOptions for getAll
getAll also accepts an object containing options, see https://googleapis.dev/nodejs/firestore/latest/Transaction.html#getAll. Currently, this breaks the mock as it is treated as a doc.