### PR TITLE
Fix Maximum call stack size exceeded in calling `firebase.auth().currentUser`

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -32,6 +32,7 @@ describe('we can start a firebase application', () => {
         { id: 'DC', name: 'Disctric of Columbia', state: 'DC', country: 'USA' },
       ],
     },
+    currentUser: { uid: 'abc123', displayName: 'Bob' },
   });
 
   beforeEach(() => {
@@ -101,6 +102,13 @@ describe('we can start a firebase application', () => {
         expect.assertions(1);
         await this.admin.auth().getUser('some-uid');
         expect(mockGetUser).toHaveBeenCalledWith('some-uid');
+      });
+
+      test('get currentUser object', async () => {
+        expect.assertions(2);
+        const currentUser = await this.admin.auth().currentUser;
+        expect(currentUser.uid).toEqual('abc123');
+        expect(currentUser.data.displayName).toBe('Bob');
       });
 
       test('set custom user claims', async () => {

--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -57,7 +57,7 @@ class FakeAuth {
   }
 
   get currentUser() {
-    const { uid, ...data } = this.currentUser;
+    const { uid, ...data } = this.currentUserRecord;
     return { uid, data };
   }
 }


### PR DESCRIPTION
# Description


I noticed that I get the `Maximum call stack size exceeded` error when I call `currentUser` in `firebase.auth()` overwritten by `mockFirebase`.  The reason for this is simple: the `FakeAuth.currentUser()` function is being called recursively inside of it. `FakeAuth` stores the `currentUser` passed to the constructor as `currentUserRecord` object, so the problem can be solved by using the `currentUserRecord` .

I added two commits. The first commit is just a test case, and you can see that it raises the `Maximum call stack size exceeded` error. The second commit fixes it.

## How to test

Simply define `mockFirebase` and call `firebase.auth().currentUser` .
