### PR TITLE
Add listCollections method to DocumentReference

### DIFF
--- a/__tests__/full-setup-google-cloud-firestore.test.js
+++ b/__tests__/full-setup-google-cloud-firestore.test.js
@@ -16,6 +16,7 @@ const {
   mockBatchSet,
   mockSettings,
   mockOnSnapShot,
+  mockListCollections,
 } = require('../mocks/firestore');
 
 describe('we can start a firestore application', () => {
@@ -229,6 +230,17 @@ describe('we can start a firestore application', () => {
 
       expect(result).toEqual(expect.any(Array));
       expect(result).toHaveLength(0);
+    });
+
+    test('listCollections calls mockListCollections', async () => {
+      const firestore = new this.Firestore();
+
+      await firestore
+        .collection('users')
+        .doc('abc123')
+        .listCollections();
+
+      expect(mockListCollections).toHaveBeenCalled();
     });
 
     test('onSnapshot single doc', async () => {

--- a/__tests__/full-setup-google-cloud-firestore.test.js
+++ b/__tests__/full-setup-google-cloud-firestore.test.js
@@ -194,6 +194,43 @@ describe('we can start a firestore application', () => {
       });
     });
 
+    test('listCollections returns a promise', async () => {
+      const firestore = new this.Firestore();
+
+      const listCollectionsPromise = firestore
+        .collection('cities')
+        .doc('LA')
+        .listCollections();
+
+      expect(listCollectionsPromise).toEqual(expect.any(Promise));
+    });
+
+    test('listCollections resolves with child collections', async () => {
+      const firestore = new this.Firestore();
+
+      const result = await firestore
+        .collection('users')
+        .doc('123abc')
+        .listCollections();
+
+      expect(result).toEqual(expect.any(Array));
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expect.any(this.Firestore.CollectionReference));
+      expect(result[0].id).toBe('cities');
+    });
+
+    test('listCollections resolves with empty array if there are no collections in document', async () => {
+      const firestore = new this.Firestore();
+
+      const result = await firestore
+        .collection('users')
+        .doc('abc123')
+        .listCollections();
+
+      expect(result).toEqual(expect.any(Array));
+      expect(result).toHaveLength(0);
+    });
+
     test('onSnapshot single doc', async () => {
       const firestore = new this.Firestore();
 

--- a/__tests__/full-setup.test.js
+++ b/__tests__/full-setup.test.js
@@ -267,6 +267,16 @@ describe.each`
       });
     });
 
+    test('listCollections method does not exist', async () => {
+      const db = firebase.firestore();
+
+      expect(() => {
+        db.collection('cities')
+          .doc('LA')
+          .listCollections();
+      }).toThrow(TypeError);
+    });
+
     test('onSnapshot single doc', async () => {
       const db = firebase.firestore();
 

--- a/mocks/firebase.js
+++ b/mocks/firebase.js
@@ -19,6 +19,9 @@ const firebaseStub = (overrides, options = defaultOptions) => {
   firestoreConstructor.Transaction = FakeFirestore.Transaction;
   firestoreConstructor.FieldPath = FakeFirestore.FieldPath;
 
+  //Remove methods which do not exist in Firebase
+  delete firestoreConstructor.DocumentReference.prototype.listCollections;
+
   // The Firebase mock
   return {
     initializeApp: mockInitializeApp,

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -49,7 +49,7 @@ class FakeFirestore {
   getAll(...params) {
     //Strip ReadOptions object
     params = params.filter(arg => arg instanceof FakeFirestore.DocumentReference);
-
+    
     return Promise.all(
       transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()),
     );

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -11,6 +11,7 @@ const mockSet = jest.fn();
 const mockAdd = jest.fn();
 const mockDelete = jest.fn();
 const mockListDocuments = jest.fn();
+const mockListCollections = jest.fn();
 
 const mockBatchDelete = jest.fn();
 const mockBatchCommit = jest.fn();
@@ -49,10 +50,8 @@ class FakeFirestore {
   getAll(...params) {
     //Strip ReadOptions object
     params = params.filter(arg => arg instanceof FakeFirestore.DocumentReference);
-    
-    return Promise.all(
-      transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()),
-    );
+
+    return Promise.all(transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()));
   }
 
   batch() {
@@ -255,6 +254,8 @@ FakeFirestore.DocumentReference = class {
   }
 
   listCollections() {
+    mockListCollections();
+
     const document = this._getRawObject();
     if (!document._collections) {
       return Promise.resolve([]);
@@ -531,6 +532,7 @@ module.exports = {
   mockBatchSet,
   mockOnSnapShot,
   mockListDocuments,
+  mockListCollections,
   ...query.mocks,
   ...transaction.mocks,
   ...fieldValue.mocks,

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -50,7 +50,9 @@ class FakeFirestore {
     //Strip ReadOptions object
     params = params.filter(arg => arg instanceof FakeFirestore.DocumentReference);
 
-    return Promise.all(transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()));
+    return Promise.all(
+      transaction.mocks.mockGetAll(...params) || [...params].map(r => r.get()),
+    );
   }
 
   batch() {


### PR DESCRIPTION
# Description

Implementation of listCollections method (see https://googleapis.dev/nodejs/firestore/latest/DocumentReference.html#listCollections) for Cloud Firestore.

## Related issues

None.

## How to test

Tests included.