### PR TITLE
Allow verifyIdToken to return mock value

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -157,6 +157,17 @@ describe('we can start a firebase application', () => {
         expect(mockGetUser).toHaveBeenCalledWith(uid);
         expect(result).toStrictEqual(userRecord);
       });
+
+      test('mocking verify ID token to throw Error', async () => {
+        const error = new Error('test');
+        expect.assertions(1);
+        mockVerifyIdToken.mockRejectedValueOnce(error);
+        const result = await this.admin
+          .auth()
+          .verifyIdToken('token_string', true)
+          .catch(err => err);
+        expect(result).toStrictEqual(error);
+      });
     });
   });
 });

--- a/mocks/auth.js
+++ b/mocks/auth.js
@@ -41,8 +41,7 @@ class FakeAuth {
   }
 
   verifyIdToken() {
-    mockVerifyIdToken(...arguments);
-    return Promise.resolve(this.currentUserRecord);
+    return Promise.resolve(mockVerifyIdToken(...arguments) || this.currentUserRecord);
   }
 
   getUser() {


### PR DESCRIPTION
# Description

Refactor `verifyIdToken()` to return mock values.

## Related issues

N/A

## How to test

Add a test to handle an error thrown via mockVerifyIdToken.
