### PR TITLE
fix: update expect assertion on @google-cloud/firestore test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ test('testing stuff', () => {
     .get()
     .then(userDocs => {
       expect(mockCollection).toHaveBeenCalledWith('users');
-      expect(userDocs[0].name).toEqual('Homer Simpson');
+      expect(userDocs.docs[0].data().name).toEqual('Homer Simpson');
     });
 });
 ```


### PR DESCRIPTION
# Description
Fixes @google-cloud/firestore documentation example to include correct expect assertion.

## Related issues
Fixes #112 


