### PR TITLE
Implementing query methods

### DIFF
--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -622,4 +622,84 @@ describe('Queries', () => {
     const animalIds = animalSnaps.docs.map(doc => doc.id);
     expect(animalIds).toMatchObject(['monkey', 'chicken', 'elephant', 'ant']);
   });
+
+  test('it returns ordered animals, with more than 2 legs', async () => {
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount').startAfter(2);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['elephant', 'ant']);
+  });
+
+  test('it returns animals ordered by legCount, after elephant', async () => {
+    const elephant = db.doc('animals/elephant');
+    const elephantSnap = await elephant.get();
+
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount').startAfter(elephantSnap);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['ant']);
+  });
+
+  test('it returns ordered animals, with 4 or more legs', async () => {
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount').startAt(4);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['elephant', 'ant']);
+  });
+
+  test('it returns animals ordered by legCount, starting at elephant', async () => {
+    const elephant = db.doc('animals/elephant');
+    const elephantSnap = await elephant.get();
+
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount').startAt(elephantSnap);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['elephant', 'ant']);
+  });
+
+  test('it returns animals ordered by legCount, starting at chicken', async () => {
+    const chicken = db.doc('animals/chicken');
+    const chickenSnap = await chicken.get();
+
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount').startAt(chickenSnap);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['chicken', 'elephant', 'ant']);
+  });
+
+  test('it returns animals ordered by name, starting after cow', async () => {
+    const cow = db.doc('animals/cow');
+    const cowSnap = await cow.get();
+
+    const animals = db.collection('animals');
+    const q = animals.orderBy('name').startAfter(cowSnap);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['elephant', 'monkey', 'pogo-stick', 'worm']);
+  });
+
+  test('it returns all documents when snapshot given to startAt does not exist', async () => {
+    const invalid = db.doc('animals/invalid');
+    const invalidSnap = await invalid.get();
+    expect(invalidSnap.exists).toBe(false);
+
+    const animals = db.collection('animals');
+    const q = animals.orderBy('name').startAt(invalidSnap);
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject([
+      'ant',
+      'chicken',
+      'cow',
+      'elephant',
+      'monkey',
+      'pogo-stick',
+      'worm',
+    ]);
+  });
 });

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -558,4 +558,23 @@ describe('Queries', () => {
       },
     );
   });
+
+  test('it limits response to 1 document', async () => {
+    const animals = db.collection('animals');
+    const q = animals.limit(1);
+    const animalsSnaps = await q.get();
+    expect(animalsSnaps.size).toBe(1);
+  });
+
+  test('it limits response to 3 document', async () => {
+    const animals = db.collection('animals');
+    const q = animals.limit(3);
+    const animalsSnaps = await q.get();
+    expect(animalsSnaps.size).toBe(3);
+  });
+
+  test('it should throw when limit is not a number', async () => {
+    const animals = db.collection('animals');
+    expect(() => animals.limit('3')).toThrow(TypeError);
+  });
 });

--- a/__tests__/query.test.js
+++ b/__tests__/query.test.js
@@ -577,4 +577,49 @@ describe('Queries', () => {
     const animals = db.collection('animals');
     expect(() => animals.limit('3')).toThrow(TypeError);
   });
+
+  test('it orders animals by name', async () => {
+    const animals = db.collection('animals');
+    const q = animals.orderBy('name');
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject([
+      'ant',
+      'chicken',
+      'cow',
+      'elephant',
+      'monkey',
+      'pogo-stick',
+      'worm',
+    ]);
+  });
+
+  test('it orders animals by name descending', async () => {
+    const animals = db.collection('animals');
+    const q = animals.orderBy('name', 'desc');
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject([
+      'worm',
+      'pogo-stick',
+      'monkey',
+      'elephant',
+      'cow',
+      'chicken',
+      'ant',
+    ]);
+  });
+
+  test('it should throw when using invalid direction', async () => {
+    const animals = db.collection('animals');
+    expect(() => animals.orderBy('name', 'invalidDirection')).toThrow();
+  });
+
+  test('it orders animals by legCount', async () => {
+    const animals = db.collection('animals');
+    const q = animals.orderBy('legCount');
+    const animalSnaps = await q.get();
+    const animalIds = animalSnaps.docs.map(doc => doc.id);
+    expect(animalIds).toMatchObject(['monkey', 'chicken', 'elephant', 'ant']);
+  });
 });

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -523,6 +523,8 @@ FakeFirestore.CollectionReference = class extends FakeFirestore.Query {
       isFilteringEnabled ? this.filters : undefined,
       this.selectFields,
       this.limitCount,
+      this.orderByField,
+      this.orderDirection,
     );
   }
 

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -522,6 +522,7 @@ FakeFirestore.CollectionReference = class extends FakeFirestore.Query {
       records,
       isFilteringEnabled ? this.filters : undefined,
       this.selectFields,
+      this.limitCount,
     );
   }
 

--- a/mocks/firestore.js
+++ b/mocks/firestore.js
@@ -525,6 +525,8 @@ FakeFirestore.CollectionReference = class extends FakeFirestore.Query {
       this.limitCount,
       this.orderByField,
       this.orderDirection,
+      this.cursor,
+      this.inclusive,
     );
   }
 

--- a/mocks/helpers/buildQuerySnapShot.d.ts
+++ b/mocks/helpers/buildQuerySnapShot.d.ts
@@ -26,4 +26,5 @@ export default function buildQuerySnapShot(
   requestedRecords: Array<DocumentHash>,
   filters?: Array<QueryFilter>,
   selectFields?: string[],
+  limit?: number,
 ): MockedQuerySnapshot;

--- a/mocks/helpers/buildQuerySnapShot.d.ts
+++ b/mocks/helpers/buildQuerySnapShot.d.ts
@@ -27,4 +27,6 @@ export default function buildQuerySnapShot(
   filters?: Array<QueryFilter>,
   selectFields?: string[],
   limit?: number,
+  orderBy?: string,
+  orderDirection?: 'asc' | 'desc',
 ): MockedQuerySnapshot;

--- a/mocks/helpers/buildQuerySnapShot.d.ts
+++ b/mocks/helpers/buildQuerySnapShot.d.ts
@@ -29,4 +29,6 @@ export default function buildQuerySnapShot(
   limit?: number,
   orderBy?: string,
   orderDirection?: 'asc' | 'desc',
+  cursor?: unknown,
+  inclusive?: boolean,
 ): MockedQuerySnapshot;

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -1,8 +1,9 @@
 const buildDocFromHash = require('./buildDocFromHash');
 
-module.exports = function buildQuerySnapShot(requestedRecords, filters, selectFields) {
+module.exports = function buildQuerySnapShot(requestedRecords, filters, selectFields, limit) {
   const definiteRecords = requestedRecords.filter(rec => !!rec);
-  const results = _filteredDocuments(definiteRecords, filters);
+  const filteredRecords = _filteredDocuments(definiteRecords, filters);
+  const results = _limitDocuments(filteredRecords, limit);
   const docs = results.map(doc => buildDocFromHash(doc, 'abc123', selectFields));
 
   return {
@@ -297,6 +298,10 @@ function _recordsWithOneOfValues(records, key, value) {
       Array.isArray(value) &&
       getValueByPath(record, key).some(v => value.includes(v)),
   );
+}
+
+function _limitDocuments(records, limit) {
+  return records.slice(0, limit);
 }
 
 function getValueByPath(record, path) {

--- a/mocks/helpers/buildQuerySnapShot.js
+++ b/mocks/helpers/buildQuerySnapShot.js
@@ -319,6 +319,15 @@ function _recordsWithOneOfValues(records, key, value) {
   );
 }
 
+/**
+ * Orders an array of mock document data by a specified field.
+ *
+ * @param {Array<DocumentHash>} records The array of records to order.
+ * @param {string} orderBy The field to order the records after.
+ * @param {'asc' | 'desc'} direction The direction to order the records. Deafault `'asc'`.
+ *
+ * @returns {Array<import('./buildDocFromHash').DocumentHash>} The ordered documents.
+ */
 function _orderedDocuments(records, orderBy, direction = 'asc') {
   const ordered = [
     ...records.filter(record => {
@@ -355,6 +364,16 @@ function _orderedDocuments(records, orderBy, direction = 'asc') {
   return direction === 'asc' ? ordered : ordered.reverse();
 }
 
+/**
+ * Returns a subsection of records, starting from a cursor, set to a field value.
+ *
+ * @param {Array<DocumentHash>} records The array of records to get a subsection of. The array should be ordered by the same field specified in the `orderBy` parameter.
+ * @param {unknown} cursor The cursor. Either a field value or a document snapshot.
+ * @param {string} orderBy The field the records are ordered by.
+ * @param {boolean} inclusive Should the record at the cursor be included.
+ *
+ * @returns {Array<import('./buildDocFromHash').DocumentHash>} The subsection of documents, starting at the `cursor`.
+ */
 function _cursoredDocuments(records, cursor, orderBy, inclusive) {
   if (_isSnapshot(cursor)) {
     // Place the cursor at a document, based on a snapshot.

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -22,6 +22,8 @@ class Query {
     // TODO: By default, Firestore orders by ID.
     this.orderByField = undefined;
     this.orderDirection = undefined;
+    this.cursor = undefined;
+    this.inclusive = undefined;
   }
 
   get() {
@@ -86,6 +88,8 @@ class Query {
       this.limitCount,
       this.orderByField,
       this.orderDirection,
+      this.cursor,
+      this.inclusive,
     );
   }
 
@@ -133,11 +137,15 @@ class Query {
     return mockOrderBy(...arguments) || this;
   }
 
-  startAfter() {
+  startAfter(snapshotOrField) {
+    this.cursor = snapshotOrField;
+    this.inclusive = false;
     return mockStartAfter(...arguments) || this;
   }
 
-  startAt() {
+  startAt(snapshotOrField) {
+    this.cursor = snapshotOrField;
+    this.inclusive = true;
     return mockStartAt(...arguments) || this;
   }
 

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -18,6 +18,7 @@ class Query {
     this.filters = [];
     this.selectFields = undefined;
     this.isGroupQuery = isGroupQuery;
+    this.limitCount = undefined;
   }
 
   get() {
@@ -79,6 +80,7 @@ class Query {
       requestedRecords,
       isFilteringEnabled ? this.filters : undefined,
       this.selectFields,
+      this.limitCount,
     );
   }
 
@@ -107,7 +109,11 @@ class Query {
     return mockOffset(...arguments) || this;
   }
 
-  limit() {
+  limit(count) {
+    if (typeof count !== 'number') {
+      throw new TypeError('Query\'s limit was not set to a number.');
+    }
+    this.limitCount = count;
     return mockLimit(...arguments) || this;
   }
 

--- a/mocks/query.js
+++ b/mocks/query.js
@@ -19,6 +19,9 @@ class Query {
     this.selectFields = undefined;
     this.isGroupQuery = isGroupQuery;
     this.limitCount = undefined;
+    // TODO: By default, Firestore orders by ID.
+    this.orderByField = undefined;
+    this.orderDirection = undefined;
   }
 
   get() {
@@ -81,6 +84,8 @@ class Query {
       isFilteringEnabled ? this.filters : undefined,
       this.selectFields,
       this.limitCount,
+      this.orderByField,
+      this.orderDirection,
     );
   }
 
@@ -117,7 +122,14 @@ class Query {
     return mockLimit(...arguments) || this;
   }
 
-  orderBy() {
+  orderBy(field, direction = 'asc') {
+    if (direction !== 'asc' && direction !== 'desc') {
+      throw new Error(
+        `Query's orderBy received invalid direction: ${direction}. Must be 'asc' or 'desc'.`,
+      );
+    }
+    this.orderByField = field;
+    this.orderDirection = direction;
     return mockOrderBy(...arguments) || this;
   }
 


### PR DESCRIPTION
# Description

I have implemented 4 methods related to the `Query` class.

- `limit()`
- `orderBy()`
- `startAt()`
- `startAfter()`

They should behave more like the actual Firestore methods.

Do note, that I have not taken `simulateQueryFilters` into consideration, but it should be a quick fix, if the new functions should only run when `simulateQueryFilters` is set to `true`.

## Limitations

In functions where values needs to be compared, only numbers, strings and timestamps are compared.

## How to test

I have added 14 tests in `query.test.js`, that test `Query.limit()`, `Query.orderBy()`, `Query.startAt()` and `Query.startAfter()`.
